### PR TITLE
adding missing translation logs

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,7 @@ export const translate: Translations.Translate = ({
     if (rest.hasOwnProperty('fallbackValue')  ) {
       return rest.fallbackValue;
     }
+    logger.warn(`No translation nor fallback found for '${key}' .`);
   }
 
   return parser.parse(text, params, locale, key);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,12 +23,12 @@ export const translate: Translations.Translate = ({
   let text = (translations[locale] || {})[key];
 
   if (fallbackLocale && text === undefined) {
-    logger.warn(`No translation provided for '${key}' key in locale '${locale}'. Trying fallback '${fallbackLocale}'`);
+    logger.debug(`No translation provided for '${key}' key in locale '${locale}'. Trying fallback '${fallbackLocale}'`);
     text = (translations[fallbackLocale] || {})[key];
   }
 
   if (text === undefined) {
-    logger.warn(`No translation provided for '${key}' key in fallback '${fallbackLocale}'.`);
+    logger.debug(`No translation provided for '${key}' key in fallback '${fallbackLocale}'.`);
     if (rest.hasOwnProperty('fallbackValue')  ) {
       return rest.fallbackValue;
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,11 +23,15 @@ export const translate: Translations.Translate = ({
   let text = (translations[locale] || {})[key];
 
   if (fallbackLocale && text === undefined) {
+    logger.warn(`No translation provided for '${key}' key in locale '${locale}'. Trying fallback '${fallbackLocale}'`);
     text = (translations[fallbackLocale] || {})[key];
   }
 
-  if (rest.hasOwnProperty('fallbackValue') && text === undefined) {
-    return rest.fallbackValue;
+  if (text === undefined) {
+    logger.warn(`No translation provided for '${key}' key in fallback '${fallbackLocale}'.`);
+    if (rest.hasOwnProperty('fallbackValue')  ) {
+      return rest.fallbackValue;
+    }
   }
 
   return parser.parse(text, params, locale, key);


### PR DESCRIPTION
Adding simple message in log to specify if the translation is missing in the selected local/fallback