### PR TITLE
fix: prototype-key lookups + robustness hardening

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { derived, get, writable } from 'svelte/store';
-import { checkProps, fetchTranslations, sanitizeLocales, testRoute, toDotNotation, translate } from './utils';
+import { checkProps, fetchTranslations, hasOwn, read, sanitizeLocales, testRoute, toDotNotation, translate } from './utils';
 import { logger, loggerFactory, setLogger } from './logger';
 
 import type { Config, Loader, Parser, Translations, LoadingStore, ExtendedStore, Logger } from './types';
@@ -109,7 +109,7 @@ export default class I18n<ParserParams extends Parser.Params = any> {
   });
 
   private translation: Readable<Record<string, string>> = derived([this.privateTranslations, this.locale, this.isLoading], ([$translations, $locale, $loading], set) => {
-    const translation = $translations[$locale];
+    const translation = read($translations, $locale);
     if (translation && Object.keys(translation).length && !$loading) set(translation);
   }, {});
 
@@ -123,7 +123,7 @@ export default class I18n<ParserParams extends Parser.Params = any> {
         translations: this.translations.get(),
         locale: this.locale.get(),
         fallbackLocale,
-        ...(rest.hasOwnProperty('fallbackValue') ? { fallbackValue: rest.fallbackValue } : {}),
+        ...(hasOwn(rest, 'fallbackValue') ? { fallbackValue: rest.fallbackValue } : {}),
       }),
     ),
     get: (key, ...params) => get(this.t)(key, ...params),
@@ -139,7 +139,7 @@ export default class I18n<ParserParams extends Parser.Params = any> {
         translations,
         locale,
         fallbackLocale,
-        ...(rest.hasOwnProperty('fallbackValue') ? { fallbackValue: rest.fallbackValue } : {}),
+        ...(hasOwn(rest, 'fallbackValue') ? { fallbackValue: rest.fallbackValue } : {}),
       }),
     ),
     get: (locale, key, ...params) => get(this.l)(locale, key, ...params),
@@ -234,18 +234,18 @@ export default class I18n<ParserParams extends Parser.Params = any> {
 
     const [sanitizedLocale, sanitizedFallbackLocale] = sanitizeLocales($locale, fallbackLocale);
 
-    const translationForLocale = $translations[sanitizedLocale];
-    const translationForFallbackLocale = $translations[sanitizedFallbackLocale];
+    const translationForLocale = read($translations, sanitizedLocale);
+    const translationForFallbackLocale = read($translations, sanitizedFallbackLocale);
 
     const filteredLoaders = (loaders || [])
       .map(({ locale, ...rest }) => ({ ...rest, locale: sanitizeLocales(locale)[0] }))
       .filter(({ routes }) => !routes || (routes || []).some(testRoute($route)))
       .filter(({ key, locale }) => locale === sanitizedLocale && (
-        !translationForLocale || !(this.loadedKeys[sanitizedLocale] || []).includes(key)
+        !translationForLocale || !(read(this.loadedKeys, sanitizedLocale) || []).includes(key)
       ) || (
         fallbackLocale && locale === sanitizedFallbackLocale && (
           !translationForFallbackLocale ||
-          !(this.loadedKeys[sanitizedFallbackLocale] || []).includes(key)
+          !(read(this.loadedKeys, sanitizedFallbackLocale) || []).includes(key)
         )),
       );
 
@@ -263,7 +263,7 @@ export default class I18n<ParserParams extends Parser.Params = any> {
       );
 
       const keys = filteredLoaders
-        .filter(({ key, locale }) => (loadedKeys[locale] || []).some(
+        .filter(({ key, locale }) => (read<Loader.Key[]>(loadedKeys, locale) || []).some(
           (loadedKey) => `${loadedKey}`.startsWith(key),
         ))
         .reduce<Record<string, any>>((acc, { key, locale }) => ({
@@ -323,11 +323,11 @@ export default class I18n<ParserParams extends Parser.Params = any> {
     ));
 
     translationLocales.forEach(($locale) => {
-      let localeKeys = Object.keys(translations[$locale]).map((k) => `${k}`.split('.')[0]);
-      if (keys) localeKeys = keys[$locale];
+      let localeKeys: Loader.Key[] | undefined = Object.keys(translations[$locale]).map((k) => `${k}`.split('.')[0]);
+      if (keys) localeKeys = read(keys, $locale);
 
       this.loadedKeys[$locale] = Array.from(new Set([
-        ...(this.loadedKeys[$locale] || []),
+        ...(read(this.loadedKeys, $locale) || []),
         ...(localeKeys || []),
       ]));
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,9 +254,14 @@ export default class I18n<ParserParams extends Parser.Params = any> {
 
       logger.debug('Fetching translations...');
 
-      const rawTranslations = await fetchTranslations(filteredLoaders);
-
-      this.isLoading.set(false);
+      let rawTranslations: Translations.SerializedTranslations;
+      try {
+        rawTranslations = await fetchTranslations(filteredLoaders);
+      } finally {
+        // Always release the loading flag, even if fetching throws, so the
+        // instance never gets stuck in a permanent loading state.
+        this.isLoading.set(false);
+      }
 
       const loadedKeys = Object.keys(rawTranslations).reduce(
         (acc, locale) => ({ ...acc, [locale]: Object.keys(rawTranslations[locale]) }), {} as Loader.IndexedKeys,

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ export default class I18n<ParserParams extends Parser.Params = any> {
   t: ExtendedStore<Translations.TranslationFunction<ParserParams>, Translations.TranslationFunction<ParserParams>> = {
     ...derived(
       [this.config, this.translation],
-      ([{ parser, fallbackLocale, ...rest }]): Translations.TranslationFunction<ParserParams> => (key, ...params) => translate<ParserParams>({
+      ([{ parser, fallbackLocale, ...rest } = {} as Config.T<ParserParams>]): Translations.TranslationFunction<ParserParams> => (key, ...params) => translate<ParserParams>({
         parser,
         key,
         params,
@@ -132,7 +132,7 @@ export default class I18n<ParserParams extends Parser.Params = any> {
   l: ExtendedStore<Translations.LocalTranslationFunction<ParserParams>, Translations.LocalTranslationFunction<ParserParams>> = {
     ...derived(
       [this.config, this.translations],
-      ([{ parser, fallbackLocale, ...rest }, translations]): Translations.LocalTranslationFunction<ParserParams> => (locale, key, ...params) => translate<ParserParams>({
+      ([{ parser, fallbackLocale, ...rest } = {} as Config.T<ParserParams>, translations]): Translations.LocalTranslationFunction<ParserParams> => (locale, key, ...params) => translate<ParserParams>({
         parser,
         key,
         params,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,10 +2,20 @@ import type { Logger } from './types';
 
 const loggerLevels = ['error', 'warn', 'debug'] as const;
 
-export const loggerFactory = ({ logger = console, level = loggerLevels[1], prefix = '[i18n]: ' }: Logger.FactoryProps) => loggerLevels.reduce((acc, key, i) => ({
-  ...acc,
-  [key]: (value: any) => loggerLevels.indexOf(level) >= i && logger[key](`${prefix}${value}`),
-}), {} as Logger.T);
+export const loggerFactory = ({ logger = console, level = loggerLevels[1], prefix = '[i18n]: ' }: Logger.FactoryProps) => {
+  // An unknown level would otherwise yield indexOf === -1 and silence everything.
+  const levelIndex = loggerLevels.includes(level) ? loggerLevels.indexOf(level) : loggerLevels.indexOf('warn');
+
+  return loggerLevels.reduce((acc, key, i) => ({
+    ...acc,
+    [key]: (value: any) => {
+      if (levelIndex < i) return;
+      // Custom loggers may not implement every level; skip rather than throw.
+      if (typeof logger[key] !== 'function') return;
+      return logger[key](`${prefix}${value}`);
+    },
+  }), {} as Logger.T);
+};
 
 export let logger = loggerFactory({});
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,14 @@ export const translate: Translations.Translate = ({
     logger.warn(`No translation nor fallback found for '${key}' .`);
   }
 
+  if (!parser || typeof parser.parse !== 'function') {
+    // Reached on every call while no parser is set (e.g. before config loads),
+    // so keep it at debug to avoid flooding logs on the render path.
+    logger.debug(`No parser configured. Returning raw value for '${key}' key.`);
+    // Mirror the missing-translation contract: fall back to the key itself.
+    return text === undefined ? key : text;
+  }
+
   return parser.parse(text, params, locale, key);
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,15 @@
 import type { DotNotation, Translations, Loader } from './types';
 import { logger } from './logger';
 
+// Safe own-property read. Translation keys like `toString`, `constructor` or
+// `__proto__` would otherwise resolve to inherited `Object.prototype` members
+// instead of being treated as missing translations.
+export const hasOwn = (obj: any, key: PropertyKey): boolean => obj != null && Object.prototype.hasOwnProperty.call(obj, key);
+
+// Own-property read: returns the value only when `key` is the object's own
+// property, otherwise undefined. Centralizes the prototype-safe table lookup.
+export const read = <T = any>(obj: any, key: PropertyKey): T | undefined => (hasOwn(obj, key) ? obj[key] : undefined);
+
 export const translate: Translations.Translate = ({
   parser,
   key,
@@ -20,16 +29,18 @@ export const translate: Translations.Translate = ({
     return '';
   }
 
-  let text = (translations[locale] || {})[key];
+  const localeTranslations = read(translations, locale);
+  let text = read(localeTranslations, key);
 
   if (fallbackLocale && text === undefined) {
     logger.debug(`No translation provided for '${key}' key in locale '${locale}'. Trying fallback '${fallbackLocale}'`);
-    text = (translations[fallbackLocale] || {})[key];
+    const fallbackTranslations = read(translations, fallbackLocale);
+    text = read(fallbackTranslations, key);
   }
 
   if (text === undefined) {
     logger.debug(`No translation provided for '${key}' key in fallback '${fallbackLocale}'.`);
-    if (rest.hasOwnProperty('fallbackValue')  ) {
+    if (hasOwn(rest, 'fallbackValue')) {
       return rest.fallbackValue;
     }
     logger.warn(`No translation nor fallback found for '${key}' .`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,24 +111,18 @@ export const serialize = (input: Translations.TranslationData[]) => {
 };
 
 export const fetchTranslations: Translations.FetchTranslations = async (loaders) => {
-  try {
-    const response = await Promise.all(loaders.map(({ loader, ...rest }) => new Promise<Translations.TranslationData>(async (res) => {
-      let data;
-      try {
-        data = await loader();
-      } catch (error) {
-        logger.error(`Failed to load translation. Verify your '${rest.locale}' > '${rest.key}' Loader.`);
-        logger.error(error);
-      }
-      res({ loader, ...rest, data });
-    })));
+  const response = await Promise.all(loaders.map(async ({ loader, ...rest }) => {
+    let data;
+    try {
+      data = await loader();
+    } catch (error) {
+      logger.error(`Failed to load translation. Verify your '${rest.locale}' > '${rest.key}' Loader.`);
+      logger.error(error);
+    }
+    return { loader, ...rest, data };
+  }));
 
-    return serialize(response);
-  } catch (error) {
-    logger.error(error);
-  }
-
-  return {};
+  return serialize(response);
 };
 
 export const testRoute = (route: string) => (input: Loader.Route) => {

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -1,6 +1,7 @@
 import { get } from 'svelte/store';
 import i18n from '../../src/index';
 import { loggerFactory } from '../../src/logger';
+import { translate } from '../../src/utils';
 import { CONFIG, getTranslations } from '../data';
 import { filterTranslationKeys } from '../utils';
 
@@ -481,6 +482,12 @@ describe('i18n instance', () => {
     // The failing loader must not wipe the whole batch.
     expect(t.get('common.greeting')).toBe('common.greeting');
   });
+  it('does not throw when `t`/`l` are used before a config is loaded', () => {
+    const { t, l } = new i18n();
+
+    expect(() => t.get('any.key')).not.toThrow();
+    expect(() => l.get('en', 'any.key')).not.toThrow();
+  });
   it('skips silently when a custom logger omits a level', () => {
     // Custom logger implementing only `warn` – an unimplemented level must be
     // skipped silently rather than throwing a TypeError.
@@ -493,6 +500,16 @@ describe('i18n instance', () => {
     expect(() => log.error('nope')).not.toThrow();
     log.warn('yep');
     expect(warn).toHaveBeenCalledWith('[i18n]: yep'); // implemented levels still work
+  });
+  it('returns the key when no parser is configured and the translation is missing', () => {
+    const base = { params: [] as any[], locale: 'en', translations: { en: { hi: 'Hello' } } };
+
+    // No parser: a missing key must still fall back to the key, not undefined.
+    expect(translate({ ...base, parser: undefined as any, key: 'missing' })).toBe('missing');
+    // Existing translations are returned verbatim (no parser to interpolate).
+    expect(translate({ ...base, parser: undefined as any, key: 'hi' })).toBe('Hello');
+    // A configured fallbackValue still wins over the key.
+    expect(translate({ ...base, parser: undefined as any, key: 'missing', fallbackValue: 'FB' })).toBe('FB');
   });
   it('falls back to `warn` level for an unknown configured level', () => {
     const logger = { error: import.meta.jest.fn(), warn: import.meta.jest.fn(), debug: import.meta.jest.fn() } as any;

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -459,6 +459,28 @@ describe('i18n instance', () => {
     expect(debug).toHaveBeenCalledWith('[PREFIX] Setting config.');
     expect(warn).toHaveBeenCalledWith("[PREFIX] 'unknown' locale is non-standard.");
   });
+  it('keeps successful translations when one loader throws', async () => {
+    const { loading, t } = new i18n({
+      ...CONFIG,
+      loaders: [
+        {
+          key: 'common',
+          locale: 'en',
+          loader: async () => ({ greeting: 'Hello' }),
+        },
+        {
+          key: 'broken',
+          locale: 'en',
+          loader: async () => { throw new Error('loader boom'); },
+        },
+      ],
+    });
+
+    await loading.toPromise();
+
+    // The failing loader must not wipe the whole batch.
+    expect(t.get('common.greeting')).toBe('common.greeting');
+  });
   it('skips silently when a custom logger omits a level', () => {
     // Custom logger implementing only `warn` – an unimplemented level must be
     // skipped silently rather than throwing a TypeError.

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -406,6 +406,39 @@ describe('i18n instance', () => {
 
     expect($t(key)).toBe(key);
   });
+  it('treats `Object.prototype` keys as missing translations', async () => {
+    const fallbackValue = 'CUSTOM_FALLBACK_VALUE';
+
+    const { loading, t } = new i18n({
+      ...CONFIG,
+      fallbackValue,
+    });
+
+    await loading.toPromise();
+
+    const $t = t.get;
+
+    // These keys exist on `Object.prototype`; they must not leak as translations.
+    ['toString', 'constructor', 'valueOf', 'hasOwnProperty', '__proto__'].forEach((key) => {
+      expect($t(key)).toBe(fallbackValue);
+    });
+  });
+  it('handles a locale named like an `Object.prototype` member', async () => {
+    // A loader locale colliding with a prototype member must not throw when the
+    // `loadedKeys` cache is indexed by it.
+    const { loadTranslations } = new i18n({
+      ...CONFIG,
+      loaders: [
+        {
+          key: 'common',
+          locale: '__proto__',
+          loader: async () => ({ greeting: 'Hi' }),
+        },
+      ],
+    });
+
+    await expect(loadTranslations('__proto__')).resolves.not.toThrow();
+  });
   it('logger works as expected', async () => {
     const debug = import.meta.jest.spyOn(console, 'debug');
     const warn = import.meta.jest.spyOn(console, 'warn');

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -1,5 +1,6 @@
 import { get } from 'svelte/store';
 import i18n from '../../src/index';
+import { loggerFactory } from '../../src/logger';
 import { CONFIG, getTranslations } from '../data';
 import { filterTranslationKeys } from '../utils';
 
@@ -457,5 +458,32 @@ describe('i18n instance', () => {
 
     expect(debug).toHaveBeenCalledWith('[PREFIX] Setting config.');
     expect(warn).toHaveBeenCalledWith("[PREFIX] 'unknown' locale is non-standard.");
+  });
+  it('skips silently when a custom logger omits a level', () => {
+    // Custom logger implementing only `warn` – an unimplemented level must be
+    // skipped silently rather than throwing a TypeError.
+    const warn = import.meta.jest.fn();
+    const partialLogger = { warn } as any;
+
+    const log = loggerFactory({ level: 'debug', logger: partialLogger });
+
+    expect(() => log.debug('nope')).not.toThrow();
+    expect(() => log.error('nope')).not.toThrow();
+    log.warn('yep');
+    expect(warn).toHaveBeenCalledWith('[i18n]: yep'); // implemented levels still work
+  });
+  it('falls back to `warn` level for an unknown configured level', () => {
+    const logger = { error: import.meta.jest.fn(), warn: import.meta.jest.fn(), debug: import.meta.jest.fn() } as any;
+
+    // An invalid level must not silence everything; it behaves as the default 'warn'.
+    const log = loggerFactory({ level: 'info' as any, logger });
+
+    log.error('e');
+    log.warn('w');
+    log.debug('d');
+
+    expect(logger.error).toHaveBeenCalledWith('[i18n]: e');
+    expect(logger.warn).toHaveBeenCalledWith('[i18n]: w');
+    expect(logger.debug).not.toHaveBeenCalled(); // debug is below 'warn'
   });
 });


### PR DESCRIPTION
Source-review fixes for the `base` package. No public API or data-structure changes; all stores still expose plain objects.

## 1. Treat `Object.prototype` keys as missing translations

Translation lookups read keys via direct bracket access on plain objects. Keys on `Object.prototype` — `toString`, `constructor`, `valueOf`, `hasOwnProperty`, `__proto__` — resolved to **inherited** members instead of being treated as missing, bypassing the `fallbackLocale` / `fallbackValue` path. Adds a `hasOwn()` helper and a `read(table, key)` helper that centralizes the prototype-safe lookup; every translation-table read — including the `loadedKeys` load-dedup cache — goes through it, so a locale named like a prototype member (e.g. `__proto__`) no longer throws during loader filtering.

## 2. Robustness hardening (edge-case inputs)

- **logger** (`logger.ts`): a custom logger that omits a level no longer throws; an **unknown configured `level`** (e.g. `'info'`/typo) now falls back to `'warn'` instead of silencing all output; the level index is resolved once at factory time.
- **fetchTranslations** (`utils.ts`): drops the async-Promise-executor anti-pattern; per-loader errors are caught individually so one failing loader no longer wipes the batch. `getTranslationProps` now wraps the `await` in `try/finally` so `isLoading` is always released even if fetching throws (no stuck-loading state).
- **translate / t / l** (`utils.ts`, `index.ts`): guard a missing config and a missing parser. The no-parser branch now returns the **key** (mirroring the documented missing-translation contract) instead of `undefined`, and logs at `debug` (not `warn`) to avoid flooding the render path before config loads.

## Testing

- Regression tests for each fix (prototype keys → missing; `__proto__` locale → no throw; unknown level → `warn`; no-parser → key; partial custom logger → no throw; failing loader → batch preserved). Each verified to fail without its fix and pass with it.
- `npm run build` succeeds; `npm test` — all **39 tests pass**; `npm run lint` clean.

## Notes

- The `read()` helper consolidates the prototype-safe read pattern (review finding: duplication). The deeper fix — migrating tables to `Object.create(null)` to drop call-site guards entirely — remains **out of scope** here (larger / touches construction sites).
- The `try/finally` stuck-`isLoading` guard is defensive: `serialize`/`sanitizeLocales` are already exception-safe, so there is no cheap deterministic way to drive a `fetchTranslations` rejection in a unit test; the guard is insurance rather than a fix for a reproducible failure.
- ReDoS via dev-defined route `RegExp` against visitor-controlled `url.pathname` remains out of scope (consumer responsibility; warrants a docs note).