### PR TITLE
feat: add config.extensions constructor pipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,8 @@ translation state, loading, caching, route matching, and preprocessing — but
 - **`base`** (here) — core, parser-agnostic, zero runtime deps.
 - **`lib`** (`sveltekit-i18n`) — `base` pre-wired with `parser-default`.
 - **`parsers`** — `parser-default`, `parser-icu`.
+- **`extensions`** — official extensions for the `config.extensions` pipe
+  (e.g. `extension-stores`).
 
 ## Tech stack (ground truth — do not assume otherwise)
 
@@ -54,7 +56,7 @@ translation state, loading, caching, route matching, and preprocessing — but
 | Path | Role |
 |------|------|
 | `src/index.ts` | entry — re-exports the class and public types |
-| `src/I18n.svelte.ts` | `class I18n` — the runes-based core (state, loading, orchestration) |
+| `src/I18n.svelte.ts` | `class I18nCore` + the exported `I18n` facade — the runes-based core (state, loading, orchestration, extension pipe) |
 | `src/utils.ts` | pure helpers (`translate`, `sanitizeLocales`, `toDotNotation`, `serialize`, `fetchTranslations`, `testRoute`) |
 | `src/logger.ts` | `loggerFactory` + module-level `logger` singleton + `setLogger` |
 | `src/types.ts` | all public/internal types |
@@ -101,6 +103,15 @@ translation state, loading, caching, route matching, and preprocessing — but
   load by itself. Don't break load-once semantics.
 - **Parser is injected, never imported.** `translate()` calls
   `config.parser.parse(value, params, locale, key)`.
+- **`config.extensions` is a construction-time pipe.** The constructor returns
+  the instance folded through the extensions left to right, so
+  `new I18n(config)` evaluates to the last extension's output; `loadConfig()`
+  strips the property and never re-pipes. Because a class cannot annotate its
+  constructor's return type, the exported `I18n` is a typed facade over the
+  local `I18nCore` class (a construct signature folds the type through the
+  tuple); the same exported name is also the instance TYPE. The raw class is
+  deliberately not exported. Extensions run after the synchronous prefix of
+  the config load — they receive a configured instance.
 - **Preprocessing.** `addTranslations` applies `preprocess` (`'full'` default |
   `'preserveArrays'` | `'none'` | custom fn) via `toDotNotation`.
   `rawTranslations` is pre-preprocess; `translations` is post-preprocess. Keep

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Core i18n functionality for SvelteKit with support for custom message parsers. T
 ✅ **Module-based** – Translations load only for visited pages  
 ✅ **Route-aware** – Automatic loading based on SvelteKit routes  
 ✅ **Component-scoped** – Multiple translation instances with custom definitions  
+✅ **Extensible** – Pipe the instance through [extensions](#extensions) to reshape or augment its surface  
 ✅ **TypeScript** – Full type support  
 ✅ **Zero dependencies** – Lightweight and fast
 
@@ -242,6 +243,35 @@ cache: 3600000 // Translations older than 1 hour refetch on the next load
 
 Set to `0` to treat translations as always stale (refetch on every load trigger). You can also drop the loaded state manually at any time with [`invalidate()`](#methods).
 
+### `extensions`
+
+Pipes the constructed instance through extension functions, left to right. Each extension receives the surface produced so far (the raw instance for the first one) and returns the surface handed on — `new I18n(config)` evaluates to the last extension's output:
+
+```javascript
+import stores from '@sveltekit-i18n/extension-stores';
+
+const { t, locale, loading } = new I18n({
+  ...config,
+  extensions: [stores],
+});
+```
+
+An extension may augment the instance in place, or replace the surface entirely (like the store adapter above). Official extensions live in the [extensions](https://github.com/sveltekit-i18n/extensions) repository; a custom extension is just a function:
+
+```javascript
+const withGreeting = (i18n) => Object.assign(i18n, {
+  greet: (name) => i18n.t('common.greeting', { name }),
+});
+
+export const i18n = new I18n({ ...config, extensions: [withGreeting] });
+
+i18n.greet('World');
+```
+
+**Notes:**
+- Applied at construction time only — a later `loadConfig()` call ignores this property.
+- When an extension returns a new object, the result is no longer `instanceof I18n`; the original instance stays reachable through whatever the extension exposes (the official extensions expose it as `instance`).
+
 ### `log`
 
 Logging configuration:
@@ -304,6 +334,7 @@ const config: Config<ParserConfig> = {
 - [sveltekit-i18n](https://github.com/sveltekit-i18n/lib) – Complete solution with default parser
 - [@sveltekit-i18n/parser-default](https://github.com/sveltekit-i18n/parsers/tree/master/parser-default) – Default message parser
 - [@sveltekit-i18n/parser-icu](https://github.com/sveltekit-i18n/parsers/tree/master/parser-icu) – ICU message format parser
+- [Extensions](https://github.com/sveltekit-i18n/extensions) – Official extensions for the `config.extensions` pipe
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -625,6 +625,71 @@ compose.
 
 ---
 
+### `extensions`
+
+**Type:** `readonly Extension.T[]` (optional)
+
+Extension functions the constructed instance is piped through, left to right.
+Each extension receives the surface produced so far — the raw instance for the
+first one — and returns the surface handed on. `new I18n(config)` evaluates to
+the **last extension's output**.
+
+**Using an official extension:**
+
+```javascript
+import { I18n } from '@sveltekit-i18n/base';
+import stores from '@sveltekit-i18n/extension-stores';
+
+const { t, locale, loading } = new I18n({
+  ...config,
+  extensions: [stores],
+});
+```
+
+**Writing your own** — an extension is just a function. It may augment the
+instance in place:
+
+```javascript
+const withGreeting = (i18n) => Object.assign(i18n, {
+  greet: (name) => i18n.t('common.greeting', { name }),
+});
+
+export const i18n = new I18n({ ...config, extensions: [withGreeting] });
+
+i18n.greet('World');
+```
+
+…or replace the surface entirely:
+
+```javascript
+const minimal = (i18n) => ({
+  t: i18n.t,
+  setLocale: i18n.setLocale,
+  instance: i18n,
+});
+```
+
+**Behavior:**
+
+- **Construction-time only.** The pipe runs once, inside the constructor. A
+  later `loadConfig()` call ignores this property — it cannot re-pipe an
+  already-constructed surface.
+- **Extensions receive a configured instance.** The synchronous part of the
+  config load (config assignment, `translations`, `initLocale` bookkeeping)
+  has already happened when the first extension runs.
+- **`instanceof` caveat.** When an extension returns a new object, the result
+  is no longer `instanceof I18n`. The original instance stays reachable through
+  whatever the extension exposes — the official extensions expose it as
+  `instance`.
+- **Typed end to end.** The type of `new I18n(config)` folds through the
+  `extensions` tuple, so the expression's type is the last extension's return
+  type (see [TypeScript](#typescript)).
+
+Official extensions live in the
+[extensions](https://github.com/sveltekit-i18n/extensions) repository.
+
+---
+
 ### `log.level`
 
 **Type:** `'error' | 'warn' | 'debug'`  
@@ -990,6 +1055,36 @@ The library provides:
 - ✅ Typed methods and reactive properties (`t` returns `string`)
 - ✅ Generic types for custom parser integration
 - ❌ Automatic translation key inference (planned for the type generator)
+
+### Extensions and the constructor's type
+
+`new I18n(config)` is typed through a construct signature that folds the
+instance type through the `config.extensions` tuple — the expression's type is
+the **last extension's return type**, inferred without any manual annotation:
+
+```typescript
+import { I18n, type Extension } from '@sveltekit-i18n/base';
+import stores from '@sveltekit-i18n/extension-stores';
+
+// Typed as the store adapter's output — destructuring is fully typed:
+const { t, locale, loading } = new I18n({ ...config, extensions: [stores] });
+```
+
+A custom extension only needs an accurate function type — `Extension.T<I, O>`
+is `(input: I) => O`:
+
+```typescript
+const withGreeting = (i18n: I18n) => Object.assign(i18n, {
+  greet: (name: string) => i18n.t('common.greeting', { name }),
+});
+
+// Typed as I18n & { greet: (name: string) => string }:
+export const i18n = new I18n({ ...config, extensions: [withGreeting] });
+```
+
+Without `extensions`, the expression is a plain `I18n<ParserParams>` — the
+exported `I18n` name is both the constructor value and the instance type, so
+`const i: I18n = new I18n(config)` works as before.
 
 For type-safe translation keys, see [Best Practices](https://github.com/sveltekit-i18n/lib/tree/master/docs/BEST_PRACTICES.md#typescript-patterns).
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,11 @@ export default tseslint.config(
       // Until then the unsafe-* family only restates that decision on every
       // line the payload flows through, so it is off; async correctness rules
       // (no-floating-promises, no-misused-promises, require-await) stay on.
+      // Omission destructuring (`const { dropped, ...rest } = obj`) is this
+      // codebase's idiom for excluding keys immutably — a rest sibling marks
+      // the extracted names as intentionally unused (tsc's noUnusedLocals
+      // already treats them that way).
+      '@typescript-eslint/no-unused-vars': ['error', { ignoreRestSiblings: true }],
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -1,11 +1,11 @@
 import { fetchTranslations, hasOwn, read, sanitizeLocales, testRoute, toDotNotation, translate } from './utils.js';
 import { logError, logger, loggerFactory, setLogger } from './logger.js';
 
-import type { Config, Loader, Parser, Translations } from './types.js';
+import type { Config, Extension, Loader, Parser, Translations } from './types.js';
 
 const defaultCache = Number.POSITIVE_INFINITY;
 
-export default class I18n<ParserParams extends Parser.Params = any> {
+class I18nCore<ParserParams extends Parser.Params = any> {
   // -- reactive state ---------------------------------------------------------
 
   #config = $state<Config.T<ParserParams> | undefined>(undefined);
@@ -39,6 +39,12 @@ export default class I18n<ParserParams extends Parser.Params = any> {
 
   constructor(config?: Config.T<ParserParams>) {
     if (config) void this.loadConfig(config);
+
+    // A constructor may return a substitute object: the instance is folded
+    // through `config.extensions` left to right, so `new I18n(config)`
+    // evaluates to the last extension's output. The extensions run after the
+    // synchronous part of `configLoader` — they receive a configured instance.
+    return (config?.extensions ?? []).reduce<any>((acc, extension) => extension(acc), this);
   }
 
   // -- reactive reads ---------------------------------------------------------
@@ -130,7 +136,9 @@ export default class I18n<ParserParams extends Parser.Params = any> {
       return;
     }
 
-    const { initLocale, fallbackLocale, translations, log, ...rest } = config;
+    // `extensions` is a construction-time directive, not configuration state —
+    // it is consumed by the constructor and must not land in `#config`.
+    const { initLocale, fallbackLocale, translations, log, extensions, ...rest } = config;
 
     if (log) setLogger(loggerFactory(log));
 
@@ -494,3 +502,26 @@ export default class I18n<ParserParams extends Parser.Params = any> {
     return promise;
   }
 }
+
+/**
+ * A class declaration cannot annotate its constructor's return type, so the
+ * extension pipe's construction-time type lives on this construct signature
+ * instead: parser params are inferred from `config.parser`, and the returned
+ * surface is the instance type folded through the `config.extensions` tuple
+ * (`const` keeps it a tuple without `as const` at the call site).
+ */
+interface I18nConstructor {
+  new <const C extends Config.T<any> = Config.T<any>>(
+    config?: C
+  ): Extension.Piped<I18nCore<Parser.FromConfig<C>>, Extension.FromConfig<C>>;
+}
+
+// The raw class is deliberately not exported — every consumer constructs
+// through the extension-aware signature. The exported name carries both
+// meanings: the value is the facade, the type is the un-piped instance.
+const I18n = I18nCore as unknown as I18nConstructor;
+
+type I18n<ParserParams extends Parser.Params = any> = I18nCore<ParserParams>;
+
+export { I18n };
+export default I18n;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { default, default as I18n } from './I18n.svelte.js';
+export { default, I18n } from './I18n.svelte.js';
 
-export type { Config, Loader, Logger, Parser, Translations } from './types.js';
+export type { Config, Extension, Loader, Logger, Parser, Translations } from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,10 +103,49 @@ export namespace Config {
      */
     cache?: number;
     /**
+     * Extensions the constructed instance is piped through, left to right.
+     * Each extension receives the surface produced so far — the raw `I18n`
+     * instance for the first one, the previous extension's output for the
+     * next — and returns the surface handed on, so `new I18n(config)`
+     * evaluates to the LAST extension's output. Applied by the constructor
+     * only; a later `loadConfig()` ignores this property.
+     *
+     * @example
+     * import stores from '@sveltekit-i18n/extension-stores';
+     *
+     * const { t, locale, loading } = new I18n({ ...config, extensions: [stores] });
+     */
+    extensions?: readonly Extension.T[];
+    /**
      * Custom logger configuration.
      */
     log?: Logger.FactoryProps;
   };
+}
+
+export namespace Extension {
+  export type Input = any;
+
+  export type Output = any;
+
+  /**
+   * An extension is a plain function over the constructed surface. It may
+   * augment its input in place and return it, or return a brand-new surface —
+   * the constructor just folds the instance through the configured extensions.
+   */
+  export type T<I = Input, O = Output> = (input: I) => O;
+
+  /** The `extensions` tuple carried by a config; `[]` when absent. */
+  export type FromConfig<C> = C extends { extensions: infer E extends readonly T[] } ? E : [];
+
+  /**
+   * Folds a surface type through an extension tuple, left to right — the
+   * construction-time type of `new I18n(config)`. A non-tuple `extensions`
+   * array (or none at all) degrades to the plain instance type.
+   */
+  export type Piped<Instance, Extensions> = Extensions extends readonly [T<any, infer O>, ...infer Rest]
+    ? Piped<O, Rest>
+    : Instance;
 }
 
 export namespace Loader {
@@ -176,6 +215,9 @@ export namespace Parser {
     */
     parse: Parse<P>;
   };
+
+  /** The parser params carried by a config's `parser`; `any` when unknown. */
+  export type FromConfig<C> = C extends { parser: T<infer P> } ? P : any;
 }
 
 export namespace Translations {

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import i18n from '../../src/index.js';
+import type { I18n } from '../../src/index.js';
 import { logger, loggerFactory, setLogger } from '../../src/logger.js';
 import { read, sanitizeLocales, testRoute, toDotNotation, translate } from '../../src/utils.js';
 import { CONFIG, getTranslations } from '../data/index.js';
@@ -467,6 +468,96 @@ describe('i18n instance', () => {
 
     expect(() => instance.t('common.key')).not.toThrow();
     expect(() => instance.l('en', 'common.key')).not.toThrow();
+  });
+});
+
+describe('i18n extensions', () => {
+  it('constructs the plain instance when no extensions are configured', () => {
+    // Assignability doubles as the type-level assertion: without extensions
+    // the construction-time type stays the instance type.
+    const instance: I18n = new i18n({ parser, log });
+
+    expect(instance).toBeInstanceOf(i18n);
+  });
+  it('pipes the instance through the extensions left to right', () => {
+    const order: string[] = [];
+    const instance = new i18n({
+      parser,
+      log,
+      extensions: [
+        (input: I18n) => { order.push('first'); return Object.assign(input, { first: true as const }); },
+        (input: I18n & { first: true }) => { order.push('second'); return Object.assign(input, { second: true as const }); },
+      ],
+    });
+
+    expect(order).toEqual(['first', 'second']);
+    // Property accesses double as type-level assertions: the construction-time
+    // type is the instance folded through the extension tuple.
+    expect(instance.first).toBe(true);
+    expect(instance.second).toBe(true);
+    expect(instance).toBeInstanceOf(i18n);
+  });
+  it('an augmenting extension keeps the instance surface intact', () => {
+    // Synchronous translations + `initLocale` activate the locale within the
+    // constructor, so `t` resolves right after construction.
+    const instance = new i18n({
+      parser,
+      log,
+      initLocale: 'en',
+      translations: { en: { 'common.key': 'value' } },
+      extensions: [(input: I18n) => Object.assign(input, { flag: true as const })],
+    });
+
+    expect(instance.flag).toBe(true);
+    // The no-op test parser returns the key, so `t` resolving proves the
+    // reactive surface survived the pipe.
+    expect(instance.t('common.key')).toBe('common.key');
+  });
+  it('a transforming extension replaces the constructed surface', () => {
+    const instance = new i18n({
+      parser,
+      log,
+      initLocale: 'en',
+      translations: { en: { 'common.key': 'value' } },
+      extensions: [(input: I18n) => ({ translate: input.t, instance: input })],
+    });
+
+    expect(instance).not.toBeInstanceOf(i18n);
+    expect(instance.instance).toBeInstanceOf(i18n);
+
+    // Bound fields survive being carried off the instance by a transform.
+    const { translate } = instance;
+    expect(translate('common.key')).toBe('common.key');
+  });
+  it('extensions receive an already configured instance', () => {
+    let seenLocales: string[] = [];
+
+    void new i18n({
+      parser,
+      log,
+      loaders,
+      extensions: [(input: I18n) => {
+        seenLocales = input.locales;
+        return input;
+      }],
+    });
+
+    expect(seenLocales).toContain('en');
+  });
+  it('`loadConfig` ignores `extensions` — the pipe is construction-only', async () => {
+    const calls = vi.fn();
+    const instance = new i18n();
+
+    await instance.loadConfig({
+      parser,
+      log,
+      initLocale: 'en',
+      translations: { en: { 'common.key': 'value' } },
+      extensions: [(input: I18n) => { calls(); return input; }],
+    });
+
+    expect(calls).not.toHaveBeenCalled();
+    expect(instance.t('common.key')).toBe('common.key');
   });
 });
 


### PR DESCRIPTION
Part of sveltekit-i18n/lib#218.

## Summary

Adds the `config.extensions` option: the constructor folds the instance through the configured extension functions left to right, so `new I18n(config)` evaluates to the **last extension's output**. This is the delivery mechanism for first-class consumption modes — the store adapter (`@sveltekit-i18n/extension-stores`, second PR of #218, in the new [extensions](https://github.com/sveltekit-i18n/extensions) repository) plugs in here:

```js
import stores from '@sveltekit-i18n/extension-stores';

const { t, locale, loading } = new I18n({ ...config, extensions: [stores] });
```

- Extensions run after the synchronous prefix of the config load, so they receive a **configured** instance (with synchronous `translations` + `initLocale`, the locale is even active).
- The pipe is construction-time only: `loadConfig()` strips the property and never re-pipes.
- A custom extension is just a function `(input) => output` — it may augment the instance in place or replace the surface entirely.

## Typing

A class declaration cannot annotate its constructor's return type, so the class becomes the local `I18nCore` and the exported `I18n` is a typed facade (`I18nConstructor`): its construct signature folds the instance type through the `extensions` tuple (`Extension.Piped` over `Extension.FromConfig`, with `Parser.FromConfig` inferring parser params; a `const` type parameter keeps the tuple literal without `as const`). The exported name carries both meanings — value (facade) and instance type — so existing `const i: I18n = new I18n(config)` annotations keep working, and without `extensions` the expression's type degrades to the plain instance.

## Notes

- The raw `I18nCore` class is deliberately not exported. If lib#229 (or a consumer) needs a subclassing seam, exporting it is a separate decision — flagged here rather than pre-committed.
- ESLint's `no-unused-vars` now sets `ignoreRestSiblings: true`: omission destructuring (`const { dropped, ...rest } = obj`) is the codebase idiom for excluding keys immutably, and tsc's `noUnusedLocals` already treats the extracted names as intentionally unused.
- Docs updated in the same commit: README.md (`extensions` config section, feature bullet, related packages), docs/README.md (reference-grade `extensions` section + TypeScript note on the construct-signature folding and the `instanceof` caveat), AGENTS.md (architecture notes, repo list).

## Tested

- `npm run lint` — clean
- `npm run build` — passes
- `npm test` — 72 passed (72), including 6 new specs: plain construction (typed as `I18n`), pipe order, augmenting extension keeps the surface intact, transforming extension replaces the surface (bound methods survive destructuring, original reachable), extensions receive a configured instance, `loadConfig()` ignores `extensions`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV)_