### PR TITLE
docs: master carries only finished product

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,12 @@ differently.**
 
 - **Default branch is `master`** (verify via `git remote show origin` if
   unsure). Never commit straight to it; never force-push a shared branch.
+- **`master` carries only finished product.** Nothing merges that is not
+  complete and shippable as-is — no temporary bootstraps or workarounds for
+  unpublished dependencies, no half-built surfaces. Branch-only scaffolding
+  (e.g. a `file:` dev dependency standing in for an unpublished package) is
+  removed before merge; until its precondition is met, the PR waits as a
+  draft.
 - **Branch from `master`, not from whatever HEAD happens to be:**
   `git fetch origin && git switch master && git pull --ff-only`, then create the
   branch. Use a descriptive prefix: `fix/<slug>`, `feat/<slug>`,


### PR DESCRIPTION
Add a rule to `AGENTS.md` §7 (Branch & push discipline): `master` carries only finished product. Nothing merges that is not complete and shippable as-is — no temporary bootstraps for unpublished dependencies, no half-built surfaces; branch-only scaffolding is removed before merge, and a PR blocked on an external precondition waits as a draft.

This is the policy already applied in practice to sveltekit-i18n/extensions#1, which stays draft until `@sveltekit-i18n/base` v3 is published.

Docs-only change — no build or test impact.

---
_Generated by [Claude Code](https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV)_