### PR TITLE
feat(api): clean up the public API for v3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ translation state, loading, caching, route matching, and preprocessing — but
 | `src/index.ts` | entry — re-exports the class and public types |
 | `src/I18n.svelte.ts` | `class I18nCore` + the exported `I18n` facade — the runes-based core (state, loading, orchestration, extension pipe) |
 | `src/utils.ts` | pure helpers (`translate`, `sanitizeLocales`, `toDotNotation`, `serialize`, `fetchTranslations`, `testRoute`) |
+| `src/exports/utils.ts` | the published `/utils` subpath — a facade re-exporting the reusable helpers and the `DotNotation` type |
 | `src/logger.ts` | `loggerFactory` + module-level `logger` singleton + `setLogger` |
 | `src/types.ts` | all public/internal types |
 | `tests/specs/index.spec.ts` | the suite |

--- a/README.md
+++ b/README.md
@@ -321,9 +321,12 @@ Full API documentation: [docs/README.md](./docs/README.md)
 ```typescript
 import { I18n, type Config } from '@sveltekit-i18n/base';
 import parser from '@sveltekit-i18n/parser-default';
-import type { Config as ParserConfig } from '@sveltekit-i18n/parser-default';
 
-const config: Config<ParserConfig> = {
+// The parser's params – the rest parameters of `t`/`l`. Annotate only when the
+// config lives on its own; `new I18n({ ... })` infers them.
+type Params = [payload?: Record<string, unknown>];
+
+const config: Config.T<Params> = {
   parser: parser(),
   loaders: [/* ... */],
 };

--- a/README.md
+++ b/README.md
@@ -307,6 +307,17 @@ Load-triggering methods return the promise of the matching load — concurrent d
 - `addTranslations(translations)` – add synchronous translations
 - `invalidate(locale?)` – mark loaded translations stale (one locale, or all); loaders run again on the next load trigger, and a load still in flight for an invalidated locale settles with its data discarded
 
+### Utilities
+
+Two helpers the instance uses internally ship from a separate subpath, for code that has to match the library's own behavior:
+
+```javascript
+import { sanitizeLocales, toDotNotation } from '@sveltekit-i18n/base/utils';
+```
+
+- `toDotNotation(input, preserveArrays?)` – the flattening behind [`preprocess`](#preprocess), for a custom `preprocess` that still wants dot notation
+- `sanitizeLocales(...locales)` – normalizes a locale from a URL, cookie or `Accept-Language` header the way the instance does, so it can be compared against `locale`
+
 Full API documentation: [docs/README.md](./docs/README.md)
 
 ## Documentation

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,8 @@ Translation namespace identifier. This acts as a prefix for translation keys.
 }
 ```
 
-**⚠️ Common Pitfall:** Using dots in the `key` will cause lookup issues:
+**⚠️ Common Pitfall:** Using dots in the `key` will cause lookup issues (a
+config-time `logger.error` reports such keys, but the loader still runs):
 
 ```javascript
 // ❌ Bad
@@ -108,9 +109,12 @@ Translation namespace identifier. This acts as a prefix for translation keys.
 
 ##### `loader` (required)
 
-**Type:** `() => Promise<Record<any, any>>`
+**Type:** `(props: { locale: string; route: string }) => Promise<Record<any, any>>`
 
-Async function that returns translation data.
+Async function that returns translation data. It receives the load context —
+the sanitized `locale` this run fetches translations for and the `route` the
+load was triggered for. Loaders that don't need the context can simply take no
+parameters.
 
 **Loading from local files:**
 
@@ -122,14 +126,35 @@ Async function that returns translation data.
 }
 ```
 
-**Loading from API:**
+**Loading from API (using the load context):**
 
 ```javascript
 {
   locale: 'en',
   key: 'common',
-  loader: async () => {
-    const response = await fetch('/api/translations/en/common');
+  loader: async ({ locale }) => {
+    const response = await fetch(`/api/translations/${locale}/common`);
+    return await response.json();
+  },
+}
+```
+
+**⚠️ `route` is context, not a cache key.** A loader runs at most once per
+locale per freshness window (see [`cache`](#cache)) — its `key` is recorded as
+loaded and it is skipped on later routes. So a loader whose payload varies by
+`route` would serve the first route's data everywhere. Scope such data with
+[`routes`](#routes-optional) instead, one loader entry per route group, and use
+the `route` argument for diagnostics, or in a loader that is scoped to exactly
+one route:
+
+```javascript
+{
+  locale: 'en',
+  key: 'checkout',
+  routes: ['/checkout'],
+  loader: async ({ locale, route }) => {
+    console.debug(`loading ${locale} translations for ${route}`);
+    const response = await fetch(`/api/translations/${locale}/checkout`);
     return await response.json();
   },
 }
@@ -166,7 +191,7 @@ Async function that returns translation data.
 
 ##### `routes` (optional)
 
-**Type:** `Array<string | RegExp>`
+**Type:** `Array<string | RegExp | { test: (route: string) => boolean }>`
 
 Array of route patterns. Loader will only execute if current route matches one of these patterns.
 
@@ -209,6 +234,25 @@ This will match:
 - `/products/category/electronics`
 - `/shop`
 - `/shop/cart`
+
+**Custom matchers:**
+
+Any value with a `test` method works. It receives the bare route path (e.g.
+`/products/123`), so a matcher that expects a full URL has to be wrapped. Keep
+it pure — a matcher may be consulted more than once per load:
+
+```javascript
+{
+  locale: 'en',
+  key: 'products',
+  routes: [
+    { test: (route) => route.startsWith('/products') },
+    // A matcher built for full URLs has to be given an origin:
+    { test: (route) => productPattern.test(new URL(route, 'https://example.com')) },
+  ],
+  loader: async () => (await import('./en/products.json')).default,
+}
+```
 
 **No routes (global):**
 
@@ -318,7 +362,7 @@ const config = {
 
 ### `preprocess`
 
-**Type:** `'full' | 'preserveArrays' | 'none' | (input: Translations.Input) => any`  
+**Type:** `'full' | 'preserveArrays' | 'none' | (input: Translations.Input) => Translations.Input`  
 **Default:** `'full'`
 
 Defines how to transform loaded translation data.
@@ -398,49 +442,53 @@ No preprocessing – keep original structure.
 
 **Input/Output:** Same structure
 
-**Usage:**
+A lookup is a single own-property read of the locale's table, not a walk down a
+path, so without flattening only its **top-level** keys resolve. For
+loader-loaded data that top level is the loader `key`:
 
 ```javascript
-// Must match your JSON structure exactly
-i18n.t('user')           // Returns entire user object
-i18n.t('user.profile')   // Returns profile object
+// loaders: [{ key: 'user', locale: 'en', loader: /* the JSON above */ }]
+i18n.t('user')           // The whole namespace, exactly as the loader returned it
+i18n.t('user.profile')   // Not found – nothing flattened this key
 ```
 
-**Use Case:** When working with complex nested structures or when your parser handles nested objects.
+**Use Case:** When your parser walks the nested structure itself, or when you read `translations` directly.
 
 #### Custom Function
 
-Create your own preprocessing logic:
+Create your own preprocessing logic. Like `'none'`, a custom function bypasses
+the dot-notation flattening entirely – its return value is stored as-is, so
+keys are then looked up exactly as the function produced them (top level only,
+see [`'none'`](#none)).
+
+The function is called once per locale with that locale's table. Its top-level
+keys are the loader `key`s – or the keys you passed to `addTranslations()` –
+with each payload nested underneath.
 
 **Example 1: Add prefixes**
 
 ```javascript
 const config = {
-  preprocess: (input) => {
-    const output = {};
-    Object.keys(input).forEach(key => {
-      output[`app.${key}`] = input[key];
-    });
-    return output;
-  },
+  preprocess: (input) => Object.fromEntries(
+    Object.entries(input).map(([key, value]) => [`app.${key}`, value]),
+  ),
 };
 
-// All keys will have 'app.' prefix
-i18n.t('app.greeting')
+// loaders: [{ key: 'common', ... }] – the namespace moves under 'app.common'
+i18n.t('app.common')
 ```
 
 **Example 2: Transform values**
 
 ```javascript
 const config = {
-  preprocess: (input) => {
-    return JSON.parse(
-      JSON.stringify(input).toUpperCase()
-    );
-  },
+  preprocess: (input) => JSON.parse(JSON.stringify(
+    input,
+    (_key, value) => (typeof value === 'string' ? value.toUpperCase() : value),
+  )),
 };
 
-// All translations will be uppercase
+// All translation values will be uppercase; keys stay untouched
 ```
 
 **Example 3: Merge with defaults**
@@ -749,15 +797,33 @@ const config = {
 **Type:** `Logger.T`  
 **Default:** `console`
 
-Custom logger instance.
+Custom logger instance. Every level method takes the prefixed `message` as its
+first argument. When the report was caused by a thrown value (e.g. a failed
+loader), the raw `error` follows as a second argument — unformatted and
+unprefixed, so your logger can render its stack or serialize it as it sees fit.
+Reports with no such value are called with the message alone, so `console`
+methods never print a trailing `undefined`.
+
+The shape matches the exported `Logger.T` type:
+
+```typescript
+type CustomLogger = {
+  error: (message: string, error?: unknown) => void;
+  warn: (message: string, error?: unknown) => void;
+  debug: (message: string, error?: unknown) => void;
+};
+```
+
+A logger may omit levels it does not care about — a missing method is skipped,
+never called.
 
 **Custom logger:**
 
 ```javascript
 const customLogger = {
-  log: (...args) => console.log('LOG:', ...args),
-  warn: (...args) => console.warn('WARN:', ...args),
   error: (...args) => console.error('ERROR:', ...args),
+  warn: (...args) => console.warn('WARN:', ...args),
+  debug: (...args) => console.debug('DEBUG:', ...args),
 };
 
 const config = {
@@ -775,12 +841,12 @@ import * as Sentry from '@sentry/browser';
 const config = {
   log: {
     logger: {
-      log: console.log,
-      warn: console.warn,
-      error: (message) => {
-        console.error(message);
-        Sentry.captureException(new Error(message));
+      error: (message, error) => {
+        console.error(message, error);
+        Sentry.captureException(error ?? new Error(message));
       },
+      warn: console.warn,
+      debug: console.debug,
     },
   },
 };
@@ -820,7 +886,10 @@ binding then stays in sync with the instance:
 
 ### `t(key, ...params)`
 
-**Type:** `(key: string, ...params: ParserParams) => string`
+**Type:** `(key: string, ...params: ParserParams) => ParserOutput`
+
+`ParserOutput` is inferred from the configured parser's `parse` return type and
+defaults to `string` (see [TypeScript](#typescript)).
 
 Translates `key` for the active locale.
 
@@ -840,7 +909,7 @@ updates when either changes. Outside templates it is an ordinary function call.
 
 ### `l(locale, key, ...params)`
 
-**Type:** `(locale: string, key: string, ...params: ParserParams) => string`
+**Type:** `(locale: string, key: string, ...params: ParserParams) => ParserOutput`
 
 Like `t`, for an explicit locale — useful for rendering a language switcher in
 each language's own name.
@@ -1034,9 +1103,13 @@ Full TypeScript support with complete type definitions:
 ```typescript
 import { I18n, type Config } from '@sveltekit-i18n/base';
 import parser from '@sveltekit-i18n/parser-default';
-import type { Config as ParserConfig } from '@sveltekit-i18n/parser-default';
 
-const config: Config<ParserConfig> = {
+// `Config.T` is generic over the parser's params (the rest parameters of
+// `t`/`l`) and, optionally, its output. Annotate only when the config lives on
+// its own — passed straight to `new I18n(...)`, both are inferred.
+type Params = [payload?: Record<string, unknown>];
+
+const config: Config.T<Params> = {
   parser: parser(),
   loaders: [
     {
@@ -1052,9 +1125,40 @@ export const i18n = new I18n(config);
 
 The library provides:
 - ✅ Complete type definitions for configuration
-- ✅ Typed methods and reactive properties (`t` returns `string`)
+- ✅ Typed methods and reactive properties (`t`/`l` output inferred from the parser)
 - ✅ Generic types for custom parser integration
 - ❌ Automatic translation key inference (planned for the type generator)
+
+### Parser params and output inference
+
+`new I18n(config)` infers both the parser's **params** (the rest parameters of
+`t`/`l`) and its **output** (their return type) from `config.parser.parse`:
+
+```typescript
+const richParser = {
+  // parse returns { html: string } instead of a string
+  parse: (value: unknown, params: unknown[], locale: string, key: string) => ({
+    html: renderSomehow(value, params),
+  }),
+};
+
+const i18n = new I18n({ parser: richParser, /* ... */ });
+
+i18n.t('home.title'); // typed { html: string }
+```
+
+Three cases yield `string`: a parser whose `parse` return type is `any`, one
+built against the untyped `Parser.T` default, and one the consumer has no types
+for at all. The common case stays ergonomic that way, and a parser producing
+anything richer has to declare its output explicitly (e.g. `Parser.T<Params,
+HtmlOutput>`).
+
+**Caveat for non-string outputs:** the fail-soft paths bypass the parser
+entirely and return a plain string — `''` when the key or the locale is
+missing, the key itself when no parser is configured yet (see
+[`fallbackValue`](#fallbackvalue)). That string is still typed as the parser's
+output, so a component consuming a rich output should tolerate it — either by
+setting a `fallbackValue` of the right shape, or by guarding the render.
 
 ### Extensions and the constructor's type
 
@@ -1082,9 +1186,12 @@ const withGreeting = (i18n: I18n) => Object.assign(i18n, {
 export const i18n = new I18n({ ...config, extensions: [withGreeting] });
 ```
 
-Without `extensions`, the expression is a plain `I18n<ParserParams>` — the
-exported `I18n` name is both the constructor value and the instance type, so
-`const i: I18n = new I18n(config)` works as before.
+Without `extensions`, the expression is a plain `I18n<ParserParams,
+ParserOutput>` — the exported `I18n` name is both the constructor value and the
+instance type. Bare `I18n` stands for the `string`-output instance, so
+`const i: I18n = new I18n(config)` fits a string parser; a rich-output parser
+needs its arguments spelled out (`I18n<Params, HtmlOutput>`), or no annotation
+at all, letting the constructor's inference stand.
 
 For type-safe translation keys, see [Best Practices](https://github.com/sveltekit-i18n/lib/tree/master/docs/BEST_PRACTICES.md#typescript-patterns).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Complete API reference for `@sveltekit-i18n/base`. This package provides core i1
 
 - [Configuration](#configuration)
 - [Instance Properties and Methods](#instance-properties-and-methods)
+- [Utilities](#utilities)
 - [TypeScript](#typescript)
 - [See Also](#see-also)
 
@@ -1093,6 +1094,65 @@ next load trigger starts a fresh fetch instead of joining it.
 Works independently of `config.cache`: with the default infinite cache it is
 the way to pick up runtime content changes; with a finite cache it forces a
 refresh before the window elapses.
+
+---
+
+## Utilities
+
+Two helpers the instance uses internally are published separately, for the
+cases where consumer code has to match the library's own behavior:
+
+```javascript
+import { sanitizeLocales, toDotNotation } from '@sveltekit-i18n/base/utils';
+```
+
+The rest of the internals stays private – the subpath exports these two, plus
+the `DotNotation` type they are described with.
+
+### `toDotNotation(input, preserveArrays?)`
+
+**Type:** `<I>(input: I, preserveArrays?: boolean) => DotNotation.Output<I>`
+
+The flattening behind [`preprocess`](#preprocess). A custom `preprocess`
+function *replaces* the built-in flattening, so call this when you want to
+transform the input and still end up with dot notation:
+
+```javascript
+import { toDotNotation } from '@sveltekit-i18n/base/utils';
+
+const defaults = { common: { error: 'An error occurred' } };
+
+const config = {
+  preprocess: (input) => toDotNotation({ ...defaults, ...input }),
+};
+
+// i18n.t('common.error')
+```
+
+Pass `true` as the second argument to keep arrays intact – the
+[`'preserveArrays'`](#preprocess) behavior.
+
+---
+
+### `sanitizeLocales(...locales)`
+
+**Type:** `(...locales: any[]) => string[]`
+
+Normalizes locales the way the instance does before storing them, so a value
+coming from a URL, a cookie or an `Accept-Language` header can be compared
+against [`locale`](#locale) and [`locales`](#locales):
+
+```javascript
+import { sanitizeLocales } from '@sveltekit-i18n/base/utils';
+
+const [locale] = sanitizeLocales(page.params.lang); // 'en-us' -> 'en-US'
+
+if (locale && locale !== i18n.locale) await i18n.setLocale(locale);
+```
+
+Falsy inputs are dropped, so the result can be shorter than the argument list.
+A locale `Intl` does not recognize is lowercased and reported through the
+[logger](#loglevel) instead of throwing.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
       "svelte": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./utils": {
+      "types": "./dist/exports/utils.d.ts",
+      "svelte": "./dist/exports/utils.js",
+      "default": "./dist/exports/utils.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -5,10 +5,10 @@ import type { Config, Extension, Loader, Parser, Translations } from './types.js
 
 const defaultCache = Number.POSITIVE_INFINITY;
 
-class I18nCore<ParserParams extends Parser.Params = any> {
+class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> {
   // -- reactive state ---------------------------------------------------------
 
-  #config = $state<Config.T<ParserParams> | undefined>(undefined);
+  #config = $state<Config.T<ParserParams, ParserOutput> | undefined>(undefined);
 
   /** The ACTIVE locale — advances only after its translations resolved. */
   #locale = $state<Config.Locale | undefined>(undefined);
@@ -37,7 +37,7 @@ class I18nCore<ParserParams extends Parser.Params = any> {
   /** In-flight loads keyed by locale and route; duplicate triggers share the promise. */
   #inflight = new Map<string, Promise<void>>();
 
-  constructor(config?: Config.T<ParserParams>) {
+  constructor(config?: Config.T<ParserParams, ParserOutput>) {
     if (config) void this.loadConfig(config);
 
     // A constructor may return a substitute object: the instance is folded
@@ -95,10 +95,10 @@ class I18nCore<ParserParams extends Parser.Params = any> {
    * tracked: the call reads the translation table and locale, so a component
    * using `{i18n.t('key')}` re-renders when either changes.
    */
-  t: Translations.TranslationFunction<ParserParams> = (key, ...params) => {
-    const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams>;
+  t: Translations.TranslationFunction<ParserParams, ParserOutput> = (key, ...params) => {
+    const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams, ParserOutput>;
 
-    return translate<ParserParams>({
+    return translate<ParserParams, ParserOutput>({
       parser,
       key,
       params,
@@ -110,10 +110,10 @@ class I18nCore<ParserParams extends Parser.Params = any> {
   };
 
   /** Like `t`, for an explicit locale. */
-  l: Translations.LocalTranslationFunction<ParserParams> = (locale, key, ...params) => {
-    const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams>;
+  l: Translations.LocalTranslationFunction<ParserParams, ParserOutput> = (locale, key, ...params) => {
+    const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams, ParserOutput>;
 
-    return translate<ParserParams>({
+    return translate<ParserParams, ParserOutput>({
       parser,
       key,
       params,
@@ -130,7 +130,7 @@ class I18nCore<ParserParams extends Parser.Params = any> {
    * Applies a config. Overridable extension seam — `sveltekit-i18n` wires its
    * default parser by extending this method.
    */
-  async configLoader(config: Config.T<ParserParams>) {
+  async configLoader(config: Config.T<ParserParams, ParserOutput>) {
     if (!config) {
       logger.error('No config provided!');
       return;
@@ -154,6 +154,18 @@ class I18nCore<ParserParams extends Parser.Params = any> {
       ...rest,
     };
 
+    // Report-only: the loader still runs, but `.` is the dot-notation
+    // separator, so a dotted key collides with the flattened namespace.
+    // `String` rather than a template literal — interpolating a Symbol throws,
+    // and a config-time report must not abort the rest of the config load.
+    (rest.loaders ?? []).forEach(({ key }) => {
+      const name = key == null ? '' : String(key);
+
+      if (name.includes('.')) {
+        logger.error(`Invalid '${name}' loader key. It shouldn't include the '.' character.`);
+      }
+    });
+
     // A reconfiguration can swap loaders or cache policy — bookkeeping from
     // the previous config must not suppress the new loaders.
     this.invalidate();
@@ -167,7 +179,7 @@ class I18nCore<ParserParams extends Parser.Params = any> {
    * promise marked handled, so a fire-and-forget call cannot become an
    * unhandled rejection; an awaiting caller still receives it.
    */
-  loadConfig = (config: Config.T<ParserParams>) => {
+  loadConfig = (config: Config.T<ParserParams, ParserOutput>) => {
     const promise = this.configLoader(config);
 
     promise.catch((error) => logError('Failed to load the i18n config.', error));
@@ -269,7 +281,7 @@ class I18nCore<ParserParams extends Parser.Params = any> {
 
     logger.debug('Fetching translations...');
 
-    const rawTranslations = await fetchTranslations(filteredLoaders);
+    const rawTranslations = await fetchTranslations(filteredLoaders, route);
 
     const loadedKeys = Object.entries(rawTranslations).reduce(
       (acc, [translationLocale, data]) => ({ ...acc, [translationLocale]: Object.keys(data ?? {}) }),
@@ -506,14 +518,15 @@ class I18nCore<ParserParams extends Parser.Params = any> {
 /**
  * A class declaration cannot annotate its constructor's return type, so the
  * extension pipe's construction-time type lives on this construct signature
- * instead: parser params are inferred from `config.parser`, and the returned
- * surface is the instance type folded through the `config.extensions` tuple
- * (`const` keeps it a tuple without `as const` at the call site).
+ * instead: parser params and output are inferred from `config.parser`, and
+ * the returned surface is the instance type folded through the
+ * `config.extensions` tuple (`const` keeps it a tuple without `as const` at
+ * the call site).
  */
 interface I18nConstructor {
-  new <const C extends Config.T<any> = Config.T<any>>(
+  new <const C extends Config.T<any, any> = Config.T<any, any>>(
     config?: C
-  ): Extension.Piped<I18nCore<Parser.FromConfig<C>>, Extension.FromConfig<C>>;
+  ): Extension.Piped<I18nCore<Parser.FromConfig<C>, Parser.OutputFromConfig<C>>, Extension.FromConfig<C>>;
 }
 
 // The raw class is deliberately not exported — every consumer constructs
@@ -521,7 +534,7 @@ interface I18nConstructor {
 // meanings: the value is the facade, the type is the un-piped instance.
 const I18n = I18nCore as unknown as I18nConstructor;
 
-type I18n<ParserParams extends Parser.Params = any> = I18nCore<ParserParams>;
+type I18n<ParserParams extends Parser.Params = any, ParserOutput = string> = I18nCore<ParserParams, ParserOutput>;
 
 export { I18n };
 export default I18n;

--- a/src/exports/utils.ts
+++ b/src/exports/utils.ts
@@ -1,0 +1,3 @@
+export { sanitizeLocales, toDotNotation } from '../utils.js';
+
+export type { DotNotation } from '../types.js';

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,7 +8,7 @@ export const loggerFactory = ({ logger = console, level = loggerLevels[1], prefi
 
   return loggerLevels.reduce((acc, key, i) => ({
     ...acc,
-    [key]: (value: any) => {
+    [key]: (message: string, error?: unknown) => {
       if (levelIndex < i) return undefined;
       try {
         // Inside the `try`: the logger is consumer code — it can be null, omit
@@ -16,7 +16,12 @@ export const loggerFactory = ({ logger = console, level = loggerLevels[1], prefi
         // nothing awaits, where a throw would become an unhandled rejection.
         if (typeof logger[key] !== 'function') return undefined;
 
-        return logger[key](`${prefix}${value}`);
+        // The prefix applies to the message only; the error passes through raw
+        // so the logger formats its stack (or serializes it) itself. Forwarded
+        // only when present — `console` would otherwise print `undefined`.
+        if (error === undefined) return logger[key](`${prefix}${message}`);
+
+        return logger[key](`${prefix}${message}`, error);
       } catch {
         return undefined;
       }
@@ -28,9 +33,8 @@ export let logger = loggerFactory({});
 
 export const setLogger = (l: Logger.T) => { logger = l; };
 
-// Single shape for every reported failure: context first, then the error,
-// which the configured logger formats like any other value.
-export const logError = (message: string, error?: any) => {
-  logger.error(message);
-  logger.error(error);
+// Single shape for every reported failure: the context message first, the raw
+// error alongside it, in one call — so a consumer's logger sees them together.
+export const logError = (message: string, error?: unknown) => {
+  logger.error(message, error);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,12 @@ export namespace Logger {
   export type Prefix = string;
 
   export type T = {
-    [key in Logger.Level]: (value: any) => void;
+    /**
+     * `message` arrives prefixed (see `FactoryProps.prefix`); `error` — when
+     * present — is the raw thrown value, passed through unformatted so the
+     * logger can render its stack or serialize it as it sees fit.
+     */
+    [key in Logger.Level]: (message: string, error?: unknown) => void;
   };
 
   export type FactoryProps = {
@@ -38,10 +43,6 @@ export namespace Logger {
 }
 
 export namespace Config {
-  export type Loader = Loader.LoaderModule;
-
-  export type Translations = Translations.T;
-
   export type Locale = Translations.Locales[number];
 
   export type InitLocale = Locale | undefined;
@@ -50,11 +51,11 @@ export namespace Config {
 
   export type FallbackValue = any;
 
-  export type T<P extends Parser.Params = Parser.Params> = {
+  export type T<P extends Parser.Params = Parser.Params, O = Parser.Output> = {
     /**
      * You can use loaders to define your asyncronous translation load. All loaded data are stored so loader is triggered only once – in case there is no previous version of the translation. It can get triggered again once the `config.cache` window elapses, or after `invalidate()` is called.
      */
-    loaders?: Loader[];
+    loaders?: Loader.LoaderModule[];
     /**
      * Locale-indexed translations, which should be in place before loaders will trigger. It's useful for static pages and synchronous translations – for example locally defined language names which are the same for all of the language mutations.
      *
@@ -77,7 +78,7 @@ export namespace Config {
      */
     fallbackValue?: FallbackValue;
     /**
-     * Preprocessor strategy or a custom function. Defines, how to transform the translation data immediately after the load.
+     * Preprocessor strategy or a custom function. Defines, how to transform the translation data immediately after the load. Note that a custom function (like `'none'`) bypasses the dot-notation flattening entirely – its return value is stored as-is, so keys are then looked up exactly as the function produced them.
      * @default 'full'
      *
      * @example 'full'
@@ -89,11 +90,11 @@ export namespace Config {
      * @example 'none'
      * {a: {b: [{c: {d: 1}}, {c: {d: 2}}]}} => {a: {b: [{c: {d: 1}}, {c: {d: 2}}]}}
      */
-    preprocess?: 'full' | 'preserveArrays' | 'none' | ((input: Translations.Input) => any);
+    preprocess?: 'full' | 'preserveArrays' | 'none' | ((input: Translations.Input) => Translations.Input);
     /**
      * This property defines translation syntax you want to use.
      */
-    parser: Parser.T<P>;
+    parser: Parser.T<P, O>;
     /**
      * Time in milliseconds the loaded translations stay fresh for. Once a locale's translations are older, the next load trigger runs its loaders again. By default, loaded translations never expire – call `invalidate()` (or set a finite `cache`) when your translation source can change at runtime, e.g. a CMS.
      *
@@ -153,9 +154,30 @@ export namespace Loader {
 
   export type Locale = Config.Locale;
 
-  export type Route = string | RegExp;
+  /**
+   * Anything with a `test` method can act as a route matcher. It receives the
+   * bare route path (e.g. `/products/123`), so a matcher built around a full
+   * URL has to be wrapped in a predicate that supplies the origin itself.
+   */
+  export type RouteMatcher = {
+    test: (route: string) => boolean;
+  };
+
+  export type Route = string | RegExp | RouteMatcher;
 
   export type IndexedKeys = Translations.LocaleIndexed<Key[]>;
+
+  /** The load context every loader is called with. */
+  export type Props = {
+    /**
+     * Sanitized locale this loader run fetches translations for.
+     */
+    locale: Locale;
+    /**
+     * Route the load was triggered for.
+     */
+    route: string;
+  };
 
   export type LoaderModule = {
     /**
@@ -171,12 +193,16 @@ export namespace Loader {
     */
     loader: T;
     /**
-    * Define routes this loader should be triggered for. You can use Regular expressions too. For example `[/\/.ome/]` will be triggered for `/home` and `/rome` route as well (but still only once). Leave this `undefined` in case you want to load this module with any route (useful for common translations).
+    * Define routes this loader should be triggered for. You can use Regular expressions or any object with a `test` method too. For example `[/\/.ome/]` will be triggered for `/home` and `/rome` route as well (but still only once). Leave this `undefined` in case you want to load this module with any route (useful for common translations).
     */
     routes?: Route[];
   };
 
-  export type T = () => Promise<Translations.Input>;
+  /**
+   * Loads translation data. Receives the load context (`locale`, `route`) –
+   * loaders that don't need it can simply take no parameters.
+   */
+  export type T = (props: Props) => Promise<Translations.Input>;
 }
 
 export namespace Parser {
@@ -190,7 +216,7 @@ export namespace Parser {
 
   export type Output = any;
 
-  export type Parse<P extends Parser.Params = Parser.Params> = (
+  export type Parse<P extends Parser.Params = Parser.Params, O = Output> = (
     /**
      * Translation value from the definitions.
     */
@@ -207,17 +233,29 @@ export namespace Parser {
      * This key is serialized path to translation (e.g., `home.content.title`)
      */
     key: Key,
-  ) => Output;
+  ) => O;
 
-  export type T<P extends Parser.Params = Parser.Params> = {
+  export type T<P extends Parser.Params = Parser.Params, O = Output> = {
     /**
      * Parse function deals with interpolation of user payload and returns interpolated message.
     */
-    parse: Parse<P>;
+    parse: Parse<P, O>;
   };
 
   /** The parser params carried by a config's `parser`; `any` when unknown. */
   export type FromConfig<C> = C extends { parser: T<infer P> } ? P : any;
+
+  /**
+   * The parser output carried by a config's `parser`; `string` when unknown.
+   * `[unknown] extends [O]` catches both `any` and `unknown` – the former from
+   * a parser without a declared output (the `Output` default), the latter from
+   * an untyped `parser` value, where inference has no return type to read. A
+   * parser producing anything richer must declare its output explicitly (e.g.
+   * `Parser.T<Params, HtmlOutput>`).
+   */
+  export type OutputFromConfig<C> = C extends { parser: T<any, infer O> }
+    ? ([unknown] extends [O] ? string : O)
+    : string;
 }
 
 export namespace Translations {
@@ -225,23 +263,9 @@ export namespace Translations {
 
   export type SerializedTranslations = LocaleIndexed<DotNotation.Input>;
 
-  export type TranslationData<T = any> = Loader.LoaderModule & { data: T };
+  export type TranslationFunction<P extends Parser.Params = Parser.Params, O = string> = (key: string, ...restParams: P) => O;
 
-  export type FetchTranslations = (loaders: Loader.LoaderModule[]) => Promise<SerializedTranslations>;
-
-  export type TranslationFunction<P extends Parser.Params = Parser.Params> = (key: string, ...restParams: P) => string;
-
-  export type LocalTranslationFunction<P extends Parser.Params = Parser.Params> = (locale: Config.Locale, key: string, ...restParams: P) => string;
-
-  export type Translate = <P extends Parser.Params = Parser.Params>(props: {
-    parser: Parser.T<P>;
-    key: string;
-    params: P;
-    translations: SerializedTranslations;
-    locale: Locales[number] | undefined;
-    fallbackLocale?: Config.FallbackLocale;
-    fallbackValue?: Config.FallbackValue;
-  }) => string;
+  export type LocalTranslationFunction<P extends Parser.Params = Parser.Params, O = string> = (locale: Config.Locale, key: string, ...restParams: P) => O;
 
   export type Input<V = any> = { [K in any]: Input<V> | V };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import type { DotNotation, Translations, Loader } from './types.js';
-import { logger } from './logger.js';
+import type { Config, DotNotation, Translations, Loader, Parser } from './types.js';
+import { logError, logger } from './logger.js';
 
 // Safe own-property read. Translation keys like `toString`, `constructor` or
 // `__proto__` would otherwise resolve to inherited `Object.prototype` members
@@ -10,7 +10,9 @@ export const hasOwn = (obj: any, key: PropertyKey): boolean => obj != null && Ob
 // property, otherwise undefined. Centralizes the prototype-safe table lookup.
 export const read = <T = any>(obj: any, key: PropertyKey): T | undefined => (hasOwn(obj, key) ? obj[key] : undefined);
 
-export const translate: Translations.Translate = ({
+// The fail-soft paths return placeholder strings (`''`, the key itself) even
+// for a parser with a non-string output — hence the `as unknown as O` casts.
+export const translate = <P extends Parser.Params = Parser.Params, O = Parser.Output>({
   parser,
   key,
   params,
@@ -18,15 +20,23 @@ export const translate: Translations.Translate = ({
   locale,
   fallbackLocale,
   ...rest
-}) => {
+}: {
+  parser: Parser.T<P, O>;
+  key: string;
+  params: P;
+  translations: Translations.SerializedTranslations;
+  locale: Translations.Locales[number] | undefined;
+  fallbackLocale?: Config.FallbackLocale;
+  fallbackValue?: Config.FallbackValue;
+}): O => {
   if (!key) {
     logger.warn(`No translation key provided ('${locale}' locale). Skipping translation...`);
-    return '';
+    return '' as unknown as O;
   }
 
   if (!locale) {
     logger.warn(`No locale provided for '${key}' key. Skipping translation...`);
-    return '';
+    return '' as unknown as O;
   }
 
   const localeTranslations = read(translations, locale);
@@ -51,40 +61,52 @@ export const translate: Translations.Translate = ({
     // so keep it at debug to avoid flooding logs on the render path.
     logger.debug(`No parser configured. Returning raw value for '${key}' key.`);
     // Mirror the missing-translation contract: fall back to the key itself.
-    return text === undefined ? key : text;
+    if (text === undefined) return key as unknown as O;
+
+    return text;
   }
 
   return parser.parse(text, params, locale, key);
 };
 
 // `Intl.Collator.supportedLocalesOf` is comparatively expensive and locales
-// repeat constantly (per loader on every load trigger, per lookup), so
-// successful lookups are cached. Failed lookups are deliberately NOT cached: a
-// locale that is temporarily unknown to Intl (e.g. before a polyfill loads)
-// can recover, and the non-standard warning stays tied to the call rather than
-// to whichever logger and level happened to be installed the first time. Only
-// string inputs are cacheable — for any other input the string form is not a
-// faithful key.
-//
-// Least-recently-used: the map is insertion-ordered and every hit reinserts, so
-// a flood of visitor-supplied locales evicts itself rather than the app's own.
+// repeat constantly — per loader on every load trigger, per lookup.
 const LOCALE_CACHE_LIMIT = 1000;
 const sanitizedLocaleCache = new Map<string, string>();
+
+// Insertion order is the eviction order, so reinserting on a hit makes it
+// least-recently-used: a flood of visitor-supplied locales evicts itself
+// rather than the app's own.
+const recallSanitizedLocale = (locale: string) => {
+  const cached = sanitizedLocaleCache.get(locale);
+
+  if (cached === undefined) return undefined;
+
+  sanitizedLocaleCache.delete(locale);
+  sanitizedLocaleCache.set(locale, cached);
+
+  return cached;
+};
+
+const rememberSanitizedLocale = (locale: string, sanitized: string) => {
+  if (sanitizedLocaleCache.size >= LOCALE_CACHE_LIMIT) {
+    sanitizedLocaleCache.delete(sanitizedLocaleCache.keys().next().value as string);
+  }
+
+  sanitizedLocaleCache.set(locale, sanitized);
+};
 
 export const sanitizeLocales = (...locales: any[]) => {
   if (!locales.length) return [];
 
   return locales.filter((locale) => !!locale).map((locale) => {
+    // Only a string is a faithful key for itself.
     const cacheable = typeof locale === 'string';
 
     if (cacheable) {
-      const cached = sanitizedLocaleCache.get(locale);
-      if (cached !== undefined) {
-        sanitizedLocaleCache.delete(locale);
-        sanitizedLocaleCache.set(locale, cached);
+      const cached = recallSanitizedLocale(locale);
 
-        return cached;
-      }
+      if (cached !== undefined) return cached;
     }
 
     let current = `${locale}`.toLowerCase();
@@ -95,13 +117,11 @@ export const sanitizeLocales = (...locales: any[]) => {
 
       current = sanitized;
 
-      if (cacheable) {
-        if (sanitizedLocaleCache.size >= LOCALE_CACHE_LIMIT) {
-          sanitizedLocaleCache.delete(sanitizedLocaleCache.keys().next().value as string);
-        }
-        sanitizedLocaleCache.set(locale, current);
-      }
+      if (cacheable) rememberSanitizedLocale(locale, current);
     } catch {
+      // Deliberately not remembered: a locale Intl does not know yet can
+      // recover, and the warning stays tied to the call rather than to
+      // whichever logger was installed first.
       logger.warn(`'${locale}' locale is non-standard.`);
     }
 
@@ -115,12 +135,9 @@ export const toDotNotation: DotNotation.T = (input, preserveArrays, parentKey) =
   }
 
   if (input && typeof input === 'object') {
-    // This runs over the whole translation set on every load, so the
-    // accumulator is mutated instead of being rebuilt per key (which is
-    // quadratic). It has a null prototype so that a literal '__proto__' key
-    // stays an own property rather than reaching the prototype setter; the
-    // single spread below restores a normal object for consumers, with
-    // DefineProperty semantics that preserve that key.
+    // Mutated in place (rebuilding per key is quadratic) into a null-prototype
+    // object, then spread once on the way out — a literal '__proto__' key stays
+    // an own property instead of reaching the prototype setter.
     const output: any = Object.create(null);
     let hasEntries = false;
 
@@ -150,7 +167,7 @@ export const toDotNotation: DotNotation.T = (input, preserveArrays, parentKey) =
   return input;
 };
 
-export const serialize = (input: Translations.TranslationData[]) => {
+export const serialize = (input: Array<Loader.LoaderModule & { data: any }>) => {
   return input.reduce((acc, { key, data, locale }) => {
     if (!data) return acc;
 
@@ -165,14 +182,13 @@ export const serialize = (input: Translations.TranslationData[]) => {
   }, {} as Translations.SerializedTranslations);
 };
 
-export const fetchTranslations: Translations.FetchTranslations = async (loaders) => {
+export const fetchTranslations = async (loaders: Loader.LoaderModule[], route: string) => {
   const response = await Promise.all(loaders.map(async ({ loader, ...rest }) => {
     let data;
     try {
-      data = await loader();
+      data = await loader({ locale: rest.locale, route });
     } catch (error) {
-      logger.error(`Failed to load translation. Verify your '${rest.locale}' > '${rest.key}' Loader.`);
-      logger.error(error);
+      logError(`Failed to load translation. Verify your '${rest.locale}' > '${rest.key}' Loader.`, error);
     }
     return { loader, ...rest, data };
   }));
@@ -180,29 +196,22 @@ export const fetchTranslations: Translations.FetchTranslations = async (loaders)
   return serialize(response);
 };
 
+// `test` advances `lastIndex` on a `g`/`y` pattern, so a route object reused
+// across navigations would match only every other time — and writing to the
+// consumer's own pattern is not ours to do, least of all when it is frozen.
+const withoutMatchState = (input: Loader.RouteMatcher) => (
+  input instanceof RegExp && (input.global || input.sticky)
+    ? new RegExp(input.source, input.flags)
+    : input
+);
+
 export const testRoute = (route: string) => (input: Loader.Route) => {
   try {
     if (typeof input === 'string') return input === route;
-    if (typeof input === 'object') {
-      // `test` advances `lastIndex` on a `g`/`y` pattern, so a route object
-      // shared across navigations would match only every other time and the
-      // consumer's own use of it would be corrupted. A throwaway copy starts at
-      // `lastIndex === 0` every time, keeps the flags' meaning (sticky still
-      // anchors), and never writes to the original — which also matters when
-      // the original is frozen.
-      //
-      // Only an actual RegExp is copied: `source`/`flags` on anything else are
-      // not a pattern, and `new RegExp(undefined)` is `/(?:)/`, which matches
-      // every route. Everything else is asked for `test` as-is, with the route
-      // passed through unchanged — a custom matcher may distinguish an unset
-      // route from the string 'undefined'.
-      const stateful = input instanceof RegExp && (input.global || input.sticky);
-      const pattern = stateful ? new RegExp(input.source, input.flags) : input;
 
-      return pattern.test(route);
-    }
-  } catch {
-    logger.error('Invalid route config!');
+    return withoutMatchState(input).test(route);
+  } catch (error) {
+    logError('Invalid route config!', error);
   }
 
   return false;

--- a/tests/specs/dist.spec.ts
+++ b/tests/specs/dist.spec.ts
@@ -50,4 +50,16 @@ describe('published artifact', () => {
     expect(table.plain).toBe('ok');
     expect(({} as any).boom).toBe(undefined); // Object.prototype untouched
   });
+
+  it('serves the reusable helpers from the shipped subpath', async () => {
+    // Imported by package name, through the `exports` map — the subpath the
+    // consumer writes, not the file path it happens to resolve to. The
+    // specifier is a variable so that TypeScript leaves the self-reference to
+    // Node instead of demanding a `rootDir`.
+    const specifier = '@sveltekit-i18n/base/utils';
+    const { sanitizeLocales, toDotNotation } = await import(specifier);
+
+    expect(toDotNotation({ user: { name: 'Name' } })).toEqual({ 'user.name': 'Name' });
+    expect(sanitizeLocales('en-us', null)).toEqual(['en-US']);
+  });
 });

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import i18n from '../../src/index.js';
 import type { I18n } from '../../src/index.js';
 import { logger, loggerFactory, setLogger } from '../../src/logger.js';
@@ -192,6 +192,25 @@ describe('i18n instance', () => {
 
     expect(instance.translations).toStrictEqual(instance.rawTranslations);
     expect(instance.translations[initLocale].common.preprocess[0].test.array).toBe('passed');
+  });
+  it('`preprocess` set to a custom function stores its output as-is', async () => {
+    const instance = new i18n({
+      loaders,
+      parser,
+      log,
+      preprocess: (input) => Object.fromEntries(
+        Object.entries(input).map(([key, value]) => [`app.${key}`, value]),
+      ),
+    });
+
+    await instance.loadTranslations(initLocale);
+
+    // A custom function replaces the flattening rather than feeding it: the
+    // nesting survives and the namespace is reachable only under the key the
+    // function produced.
+    expect(instance.translations[initLocale]['app.common'].preprocess[0].test.array).toBe('passed');
+    expect(instance.translations[initLocale].common).toBeUndefined();
+    expect(instance.rawTranslations[initLocale].common.preprocess[0].test.array).toBe('passed');
   });
   it('initializes properly with `initLocale`', async () => {
     const instance = new i18n();
@@ -462,6 +481,114 @@ describe('i18n instance', () => {
 
     expect(instance.t('common.greeting')).toBe('Hello');
     expect(errorSpy).toHaveBeenCalled();
+  });
+  it('a loader receives its sanitized locale and the triggering route', async () => {
+    const received: unknown[] = [];
+    const instance = new i18n({
+      parser,
+      log,
+      loaders: [
+        { key: 'common', locale: 'EN', loader: async (props) => { received.push(props); return { greeting: 'Hello' }; } },
+      ],
+    });
+
+    await instance.loadTranslations('en', '/path');
+
+    expect(received).toEqual([{ locale: 'en', route: '/path' }]);
+  });
+  it('a fallback-locale loader receives its own locale, not the requested one', async () => {
+    const received: unknown[] = [];
+    const push = async (props: { locale: string; route: string }) => { received.push(props); return { greeting: 'Hello' }; };
+    const instance = new i18n({
+      parser,
+      log,
+      fallbackLocale: 'EN',
+      loaders: [
+        { key: 'common', locale: 'EN', loader: push },
+        { key: 'common', locale: 'DE', loader: push },
+      ],
+    });
+
+    await instance.loadTranslations('de', '/path');
+
+    expect(received).toEqual(expect.arrayContaining([
+      { locale: 'de', route: '/path' },
+      { locale: 'en', route: '/path' },
+    ]));
+    expect(received).toHaveLength(2);
+  });
+  it('forwards a thrown loader value to the configured logger unwrapped', async () => {
+    const errorSpy = vi.fn();
+    const boom = new Error('loader boom');
+    const instance = new i18n({
+      parser,
+      log: { level: 'error', logger: { error: errorSpy, warn: () => {}, debug: () => {} } },
+      loaders: [
+        { key: 'broken', locale: 'en', loader: async () => { throw boom; } },
+      ],
+    });
+
+    await instance.loadTranslations('en', '/');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[i18n]: Failed to load translation. Verify your 'en' > 'broken' Loader.",
+      boom,
+    );
+  });
+  it('matches `routes` through a custom matcher object', async () => {
+    const seen: string[] = [];
+    const instance = new i18n({
+      parser,
+      log,
+      loaders: [
+        {
+          key: 'common',
+          locale: 'en',
+          routes: [{ test: (route: string) => { seen.push(route); return route.startsWith('/products'); } }],
+          loader: async () => ({ greeting: 'Hello' }),
+        },
+      ],
+    });
+
+    await instance.loadTranslations('en', '/about');
+    expect(instance.translations['en']).toBeUndefined();
+
+    await instance.loadTranslations('en', '/products/123');
+    expect(instance.translations['en']['common.greeting']).toBe('Hello');
+    // The matcher may be consulted more than once per load — it is given the
+    // bare route path every time, never a full URL.
+    expect(Array.from(new Set(seen))).toEqual(['/about', '/products/123']);
+  });
+  it('reports a non-string loader key without throwing', async () => {
+    const errorSpy = vi.fn();
+    const instance = new i18n();
+
+    await expect(instance.loadConfig({
+      parser,
+      log: { level: 'error', logger: { error: errorSpy, warn: () => {}, debug: () => {} } },
+      loaders: [
+        { key: Symbol('common') as unknown as string, locale: 'en', loader: async () => ({ greeting: 'Hello' }) },
+      ],
+    })).resolves.toBeUndefined();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+  it('reports a loader key containing a `.` character but keeps the loader', async () => {
+    const errorSpy = vi.fn();
+    const instance = new i18n();
+
+    await instance.loadConfig({
+      parser,
+      log: { level: 'error', logger: { error: errorSpy, warn: () => {}, debug: () => {} } },
+      initLocale: 'en',
+      loaders: [
+        { key: 'common.nested', locale: 'en', loader: async () => ({ greeting: 'Hello' }) },
+      ],
+    });
+
+    expect(errorSpy).toHaveBeenCalledWith("[i18n]: Invalid 'common.nested' loader key. It shouldn't include the '.' character.");
+    // Report-only: the loader still ran and its data landed in the table.
+    expect(read(instance.translations['en'], 'common.nested.greeting')).toBe('Hello');
   });
   it('does not throw when `t`/`l` are used before a config is loaded', () => {
     const instance = new i18n();
@@ -980,6 +1107,18 @@ describe('logger', () => {
     expect(logger.warn).toHaveBeenCalledWith('[i18n]: shown');
     expect(logger.debug).not.toHaveBeenCalled();
   });
+  it('passes the raw error alongside the prefixed message', () => {
+    const logger = { error: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+    const output = loggerFactory({ level: 'error', logger });
+    const error = new Error('boom');
+
+    output.error('context', error);
+    expect(logger.error).toHaveBeenCalledWith('[i18n]: context', error);
+
+    // No error → single-argument call, so `console` does not print `undefined`.
+    output.error('no error attached');
+    expect(logger.error).toHaveBeenLastCalledWith('[i18n]: no error attached');
+  });
 });
 
 describe('translate', () => {
@@ -996,6 +1135,39 @@ describe('translate', () => {
   });
 });
 
+describe('type inference', () => {
+  it('infers the `t`/`l` output type from the configured parser', () => {
+    const richParser = { parse: (_value: unknown, _params: unknown[], _locale: string, key: string) => ({ html: key }) };
+    const rich = new i18n({ parser: richParser, log });
+    const plain = new i18n({ parser, log });
+
+    // A parser declaring a rich output surfaces it on `t`/`l`.
+    expectTypeOf(rich.t('key')).toEqualTypeOf<{ html: string }>();
+
+    // An undeclared parser output (`any`) still surfaces as `string`.
+    expectTypeOf(plain.t('key')).toEqualTypeOf<string>();
+    expectTypeOf(plain.l('en', 'key')).toEqualTypeOf<string>();
+
+    // Load methods resolve with no value.
+    expectTypeOf(plain.setLocale('en')).toEqualTypeOf<Promise<void>>();
+
+    expect(rich).toBeInstanceOf(i18n);
+    expect(plain).toBeInstanceOf(i18n);
+  });
+
+  it('falls back to a `string` output for an untyped parser', () => {
+    // A parser the consumer has no types for: inference has no return type to
+    // read, so the output has to degrade to `string` like an undeclared one.
+    const untypedParser: any = parser;
+    const instance = new i18n({ parser: untypedParser, log });
+
+    expectTypeOf(instance.t('key')).toEqualTypeOf<string>();
+    expectTypeOf(instance.l('en', 'key')).toEqualTypeOf<string>();
+
+    expect(instance).toBeInstanceOf(i18n);
+  });
+});
+
 describe('utils', () => {
   // The library logs through one module-level singleton, so a test that
   // asserts on its output installs a capturing logger and restores the
@@ -1003,13 +1175,14 @@ describe('utils', () => {
   // the level for every later test.
   const captureLogs = () => {
     const previous = logger;
-    const captured = { error: [] as string[], warn: [] as string[] };
+    type Entry = { message: string; error?: unknown };
+    const captured = { error: [] as Entry[], warn: [] as Entry[] };
 
     setLogger(loggerFactory({
       level: 'warn',
       logger: {
-        error: (value: any) => { captured.error.push(`${value}`); },
-        warn: (value: any) => { captured.warn.push(`${value}`); },
+        error: (message: any, error?: unknown) => { captured.error.push({ message: `${message}`, error }); },
+        warn: (message: any, error?: unknown) => { captured.warn.push({ message: `${message}`, error }); },
       } as any,
     }));
 
@@ -1032,7 +1205,7 @@ describe('utils', () => {
       restore();
     }
 
-    expect(captured.warn.filter((message) => message.includes('qqq-alpha'))).toHaveLength(2);
+    expect(captured.warn.filter(({ message }) => message.includes('qqq-alpha'))).toHaveLength(2);
   });
   it('`sanitizeLocales` does not let a non-string input poison a string key', () => {
     const { restore } = captureLogs();
@@ -1088,23 +1261,45 @@ describe('utils', () => {
     expect(testRoute('/shop/cart')(Object.freeze(/cart/y))).toBe(false);
   });
   it('keeps matching a duck-typed route matcher', () => {
-    // `Loader.Route` is typed `string | RegExp`, but this ships as JS, so
-    // anything object-shaped is asked for `test` and consumers rely on it.
+    // `Loader.Route` officially admits any object with a `test` method — the
+    // matcher decides for itself.
     const matcher = { test: (route: string) => route.startsWith('/shop') };
 
-    expect(testRoute('/shop/cart')(matcher as any)).toBe(true);
-    expect(testRoute('/about')(matcher as any)).toBe(false);
+    expect(testRoute('/shop/cart')(matcher)).toBe(true);
+    expect(testRoute('/about')(matcher)).toBe(false);
 
     // Its own `test` decides even when it carries pattern-shaped properties:
     // copying it would produce `new RegExp(undefined)`, i.e. match everything.
     const flagged = { global: true, test: (route: string) => route.startsWith('/shop') };
 
-    expect(testRoute('/about')(flagged as any)).toBe(false);
-    expect(testRoute('/shop')({ sticky: true, source: 'nope', test: () => false } as any)).toBe(false);
+    expect(testRoute('/about')(flagged)).toBe(false);
+    expect(testRoute('/shop')({ sticky: true, source: 'nope', test: () => false })).toBe(false);
 
     // The route reaches a custom matcher unchanged, so it can tell an unset
     // route from the string 'undefined'.
-    expect(testRoute(undefined as any)({ test: (route: any) => route === undefined } as any)).toBe(true);
+    expect(testRoute(undefined as any)({ test: (route: any) => route === undefined })).toBe(true);
+  });
+  it('asks a callable route matcher for its `test` method', () => {
+    // `Loader.Route` admits anything carrying `test`, and a function carries
+    // properties like any other object — typing one as a matcher must not turn
+    // it into a silent non-match.
+    const matcher = Object.assign(() => true, { test: (route: string) => route.startsWith('/shop') });
+
+    expect(testRoute('/shop/cart')(matcher)).toBe(true);
+    expect(testRoute('/about')(matcher)).toBe(false);
+  });
+  it('reports a route that carries no `test` method', () => {
+    const { captured, restore } = captureLogs();
+
+    try {
+      // A bare predicate is not a `Loader.Route` — it has to be reported, not
+      // dropped without a trace.
+      expect(testRoute('/contact')(((route: string) => route === '/contact') as any)).toBe(false);
+    } finally {
+      restore();
+    }
+
+    expect(captured.error.some(({ message }) => message.includes('Invalid route config!'))).toBe(true);
   });
   it('rejects a route that is not a pattern instead of coercing it', () => {
     const { captured, restore } = captureLogs();
@@ -1119,6 +1314,22 @@ describe('utils', () => {
     }
 
     expect(matched).toBe(false);
-    expect(captured.error.some((message) => message.includes('Invalid route config!'))).toBe(true);
+    expect(captured.error.some(({ message }) => message.includes('Invalid route config!'))).toBe(true);
+  });
+  it('forwards the error a throwing route matcher raised', () => {
+    const { captured, restore } = captureLogs();
+    const boom = new Error('matcher boom');
+
+    try {
+      expect(testRoute('/contact')({ test: () => { throw boom; } })).toBe(false);
+    } finally {
+      restore();
+    }
+
+    // The context message alone cannot say WHICH matcher blew up or how — the
+    // thrown value has to reach the consumer's logger unwrapped.
+    const reported = captured.error.find(({ message }) => message.includes('Invalid route config!'));
+
+    expect(reported?.error).toBe(boom);
   });
 });

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -3,6 +3,8 @@ import i18n from '../../src/index.js';
 import type { I18n } from '../../src/index.js';
 import { logger, loggerFactory, setLogger } from '../../src/logger.js';
 import { read, sanitizeLocales, testRoute, toDotNotation, translate } from '../../src/utils.js';
+import * as publicUtils from '../../src/exports/utils.js';
+import type { DotNotation } from '../../src/exports/utils.js';
 import { CONFIG, getTranslations } from '../data/index.js';
 import { filterTranslationKeys } from '../utils/index.js';
 
@@ -1169,6 +1171,12 @@ describe('type inference', () => {
 });
 
 describe('utils', () => {
+  it('publishes the reusable helpers, and only those', () => {
+    expect(publicUtils.toDotNotation).toBe(toDotNotation);
+    expect(publicUtils.sanitizeLocales).toBe(sanitizeLocales);
+    expect(Object.keys(publicUtils).sort()).toEqual(['sanitizeLocales', 'toDotNotation']);
+    expectTypeOf(publicUtils.toDotNotation).toEqualTypeOf<DotNotation.T>();
+  });
   // The library logs through one module-level singleton, so a test that
   // asserts on its output installs a capturing logger and restores the
   // previous one afterwards — restoring anything else would silently change


### PR DESCRIPTION
## What

The v3 public API cleanup:

- **Loaders receive a load context.** `Loader.T` is now
  `(props: { locale, route }) => Promise`. The `locale` is
  the loader's own, sanitized; `route` is the route the load was triggered for.
  Zero-arg loaders keep working unchanged.
- **Parser output threads through the types.** `Parser.Parse` and `Parser.T`
  gain an output generic, `t`/`l` return it, and `new I18n(config)` infers it
  from the configured parser through the new `Parser.OutputFromConfig`
  (`any`- and `unknown`-typed parser outputs coerce back to `string`).
- **Structured logger contract.** Every level is `(message: string, error?:
  unknown) => void`, with the raw error forwarded only when there is one.
  `logError` makes a single call, so an error the library catches reaches the
  consumer's logger unwrapped instead of stringified into the message.
- **Route matchers are officially typed.** `Loader.Route` admits a string or
  anything with a `test(route)` method (`Loader.RouteMatcher`). A route entry
  that carries no such method is now reported through the logger instead of
  silently never matching.
- **Report-only config validation** for loader keys containing `.`, which
  would collide with the dot notation produced by preprocessing.
- **`preprocess` custom function is typed** as
  `(input: Translations.Input) => Translations.Input` and documented as
  bypassing flattening.
- **Internal-nature type aliases dropped** from the public surface:
  `Config.Loader`, `Config.Translations`, and
  `Translations.{Translate,FetchTranslations,TranslationData}`.
- **`toDotNotation` and `sanitizeLocales` are published** from the new
  `@sveltekit-i18n/base/utils` subpath (second commit), along with the
  `DotNotation` type they are described with — the helpers and their type come
  from the same import path.

## Why

These are the last shape changes we want to make before the surface is frozen
for 3.0.0. Loaders could not tell which locale or route they were loading for
without closing over it at config time; parser output was pinned to `string`,
so an ICU-style parser returning something richer had no way to express it; the
logger received pre-stringified errors, losing the stack; and route matching
silently swallowed a misconfigured entry.

A custom `preprocess` function *replaces* the built-in flattening, so consumers
who want to transform the input and still end up with dot notation had nothing
to call; matching the instance's own locale normalization meant reimplementing
the `Intl.Collator` rules and letting them drift. Both helpers existed already
and only needed a published path.

Closes sveltekit-i18n/lib#219 (absorbs sveltekit-i18n/lib#191 and
sveltekit-i18n/lib#189).

## How

`testRoute` copies a `g`/`y`-flagged `RegExp` before calling `test`, so a
matcher reused across navigations cannot match only every other time and the
consumer's own pattern is never written to (it may be frozen). Everything else
is asked for `test` as-is; junk that carries no `test` throws into the existing
catch and is reported rather than silently returning `false`.

`Parser.OutputFromConfig` uses an `[unknown] extends [O]` guard, which catches
both `any` and `unknown`, so an untyped parser still yields `string` instead of
poisoning `t`'s return type.

The helpers are published without widening the surface any further: the second
commit only adds `src/exports/utils.ts`, a three-line facade that re-exports
the two functions and `DotNotation` and is what the `exports` map points
`./utils` at. `src/utils.ts` keeps the internals and its short import path, and
stays unreachable for consumers because the map does not name it
(`ERR_PACKAGE_PATH_NOT_EXPORTED`). One file per published subpath, so the next
one has somewhere to go.

The justification comments on `sanitizeLocales` and `toDotNotation` got the
same treatment as `testRoute`: the LRU cache read/write are now named
(`recallSanitizedLocale`, `rememberSanitizedLocale`) instead of explained, and
the remaining rationale sits at the line it applies to.

## Testing

All run on the branch tip:

- `npm run lint` — exit 0
- `npm run typecheck` — exit 0
- `npm run build` — exit 0
- `npm test` — 86 passed (86)
- `npm run test:dist` — 4 passed (4)

New specs cover the loader context argument, the logger's `(message, error)`
contract, route matchers (string, plain `RegExp`, stateful `g`/`y` `RegExp`
reused across navigations, custom `test` object, and an invalid entry being
reported), the loader-key validation, the typed `preprocess` function, and the
published helper surface — its exact runtime keys and `toDotNotation`'s type
against `DotNotation.T`.

The shipped-artifact spec imports the subpath **by package name**, so it
exercises the `exports` map rather than a `dist/` path. Verified red by
renaming the map key: the spec fails with `ERR_PACKAGE_PATH_NOT_EXPORTED`, and
passes again once restored — a typo in `package.json` cannot slip through.

## Checklist

- [x] **Tests pass locally** (`npm test`)
- [x] **Linter passes** (`npm run lint`)
- [x] **Build succeeds** (`npm run build`)
- [x] **All commits are atomic** (each commit works independently)
- [x] **Commits have clear messages** (imperative mood, descriptive)
- [x] **Branch rebased on latest master** (`git rebase origin/master`)
- [ ] **CHANGELOG.md updated** — no CHANGELOG file in this repo; the v3 release
      notes will carry these changes
- [x] **Documentation updated** — `README.md` and `docs/README.md` follow the
      new signatures; the `log.logger` examples' nonexistent `log` level was
      replaced with the real `error`/`warn`/`debug` contract; both READMEs gain
      a `Utilities` section for the new subpath, and `AGENTS.md`'s repository
      map gains the facade module

## Additional Notes

Out of scope, tracked separately:

- Per-request SSR isolation (sveltekit-i18n/lib#231) — next in the 3.0 train.
- The remaining helpers (`translate`, `serialize`, `fetchTranslations`,
  `testRoute`, `hasOwn`, `read`) stay internal. `fetchTranslations` and
  `serialize` are the ones #231 is likely to reshape, so publishing them now
  would freeze a shape we do not trust yet.
- `AGENTS.md` §11 still refers to the removed `t.get()`/`l.get()` duals; that
  predates this branch and is fixed separately on `master`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV)_