### PR TITLE
feat: per-request SSR instances and configurable locale keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Load-triggering methods return the promise of the matching load — concurrent d
 - `addTranslations(translations)` – add synchronous translations
 - `snapshot()` – serialize the active locale (and the fallback) for the current route, shaped like `config.translations` so the receiving instance hydrates from it
 - `invalidate(locale?)` – mark loaded translations stale (one locale, or all); loaders run again on the next load trigger, and a load still in flight for an invalidated locale settles with its data discarded
+- `destroy()` – detach a per-request or per-component instance: in-flight loads settle discarded, further load and mutation calls are ignored, reads keep working
 
 ### Utilities
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Load-triggering methods return the promise of the matching load — concurrent d
 - `setRoute(route)` – update the current route
 - `loadConfig(config)` – (re)configure the instance
 - `addTranslations(translations)` – add synchronous translations
+- `snapshot()` – serialize the active locale (and the fallback) for the current route, shaped like `config.translations` so the receiving instance hydrates from it
 - `invalidate(locale?)` – mark loaded translations stale (one locale, or all); loaders run again on the next load trigger, and a load still in flight for an invalidated locale settles with its data discarded
 
 ### Utilities

--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ export const load = async ({ url }) => {
 };
 ```
 
+> **Rendering per-visitor locales on the server?** The instance above is a
+> module-level singleton — on the server it is shared by every request in the
+> process, so concurrent visitors overwrite each other's locale. Use one
+> instance per request and hand its data to the client with `snapshot()`:
+> see [Server-Side Rendering](./docs/README.md#server-side-rendering).
+
 ### 4. Use in components
 
 ```svelte

--- a/docs/README.md
+++ b/docs/README.md
@@ -330,8 +330,8 @@ const config = {
 
 Synchronous translations that are available immediately, before any loaders execute.
 
-Locale keys are normalized the way [`sanitizeLocales()`](#sanitizelocaleslocales)
-normalizes them, so `EN` and `en` are one entry — the one `t()` reads.
+Locale keys are normalized per [`sanitizeLocales`](#sanitizelocales), so by
+default `EN` and `en` are one entry — the one `t()` reads.
 
 **Use Cases:**
 - Language names (same across all locales)
@@ -609,6 +609,67 @@ i18n.t('unknown.key')  // → ""
 - Hide missing translations in production
 - Show consistent placeholder
 - Debugging (default behavior shows missing keys)
+
+---
+
+### `sanitizeLocales`
+
+**Type:** `boolean | ((locale: string) => string)` (optional)  
+**Default:** `true`
+
+How locale identifiers are normalized before they key anything —
+[`translations`](#translations), [`loaders`](#loaders),
+[`initLocale`](#initlocale), [`fallbackLocale`](#fallbacklocale), the
+[translation tables](#translations--rawtranslations) and every locale you pass
+to `l()`, `setLocale()`, `loadTranslations()` or
+[`invalidate()`](#invalidatelocale).
+
+**Default (`true`) — ISO normalization:**
+
+```javascript
+const config = {
+  // sanitizeLocales: true — 'en-us', 'EN-US' and 'en-US' are one locale: 'en-US'
+};
+```
+
+Locales are resolved through `Intl`, so one locale is spelled one way no matter
+where the value came from — a URL segment, a cookie, an `Accept-Language`
+header. A locale `Intl` does not recognize is lowercased and reported through
+the [logger](#loglevel).
+
+**`false` — locales stay exactly as authored:**
+
+```javascript
+const config = {
+  sanitizeLocales: false,
+  translations: { CS: { greeting: 'Ahoj' } },
+};
+
+i18n.locale;  // → 'CS'
+```
+
+Nothing is normalized, so `CS` and `cs` are two different locales. Use this
+when your locale identifiers are not ISO codes, or when their exact spelling is
+part of your URLs.
+
+**A function — normalize your way:**
+
+```javascript
+const config = {
+  sanitizeLocales: (locale) => locale.toLowerCase(),  // 'en-US' -> 'en-us'
+};
+```
+
+The function receives every locale before it is used as a key, and its return
+value is what gets stored and reported by [`locale`](#locale) and
+[`locales`](#locales). It runs on lookups too, so keep it cheap and pure. A
+call that throws — or returns nothing usable — falls back to the locale as
+authored and is reported through the [logger](#loglevel).
+
+**Use Cases:**
+- **Default:** one spelling per locale, whatever the source
+- **`false`:** non-ISO locale identifiers, or spellings that have to round-trip
+- **Function:** a project-wide convention (e.g. always lowercase)
 
 ---
 
@@ -917,8 +978,9 @@ updates when either changes. Outside templates it is an ordinary function call.
 **Type:** `(locale: string, key: string, ...params: ParserParams) => ParserOutput`
 
 Like `t`, for an explicit locale — useful for rendering a language switcher in
-each language's own name. The locale is normalized before the lookup, so
-`l('EN', ...)` and `l('en', ...)` read the same table.
+each language's own name. The locale is normalized before the lookup
+([`sanitizeLocales`](#sanitizelocales)), so by default `l('EN', ...)` and
+`l('en', ...)` read the same table.
 
 ---
 
@@ -998,7 +1060,7 @@ gate the first render:
 
 The locale-indexed tables — `rawTranslations` before preprocessing,
 `translations` after. Indexed by the normalized locale
-([`sanitizeLocales()`](#sanitizelocaleslocales)), the same value
+([`sanitizeLocales`](#sanitizelocales)), the same value
 [`locale`](#locale) reports. Treat them as read-only; use `addTranslations()`
 to write.
 
@@ -1071,8 +1133,7 @@ the rejection.
 Adds translations synchronously (static tables known ahead of time). Payload is
 preprocessed per `config.preprocess` and merged into the tables; already-added
 keys count as loaded, so matching loaders will not refire. Locale keys are
-normalized ([`sanitizeLocales()`](#sanitizelocaleslocales)) before they are
-merged.
+normalized ([`sanitizeLocales`](#sanitizelocales)) before they are merged.
 
 ```javascript
 i18n.addTranslations({
@@ -1367,6 +1428,10 @@ if (locale && locale !== i18n.locale) await i18n.setLocale(locale);
 Falsy inputs are dropped, so the result can be shorter than the argument list.
 A locale `Intl` does not recognize is lowercased and reported through the
 [logger](#loglevel) instead of throwing.
+
+This is the DEFAULT normalization only: an instance configured with
+[`sanitizeLocales`](#sanitizelocales) keys its locales its own way, so a value
+compared against [`locale`](#locale) has to go through that same transform.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1070,6 +1070,58 @@ i18n.addTranslations({
 
 ---
 
+### `snapshot()`
+
+**Type:** `() => Record<string, any>`
+
+Serializes what the instance currently holds for the **active locale** and the
+**`fallbackLocale`**, narrowed to the current route. The result is shaped like
+[`translations`](#translations), so the receiving instance hydrates by handing
+it straight to its constructor — the bookkeeping derived from it keeps the
+matching loaders from fetching the same data again:
+
+```javascript
+// +layout.server.js — one instance per request
+import { I18n } from '@sveltekit-i18n/base';
+import { config } from '$lib/translations';
+
+export const load = async ({ url, locals }) => {
+  const i18n = new I18n(config);
+
+  await i18n.loadTranslations(locals.locale, url.pathname);
+
+  return { locale: locals.locale, translations: i18n.snapshot() };
+};
+```
+
+```javascript
+// +layout.js — the client starts from the server's data
+import { I18n } from '@sveltekit-i18n/base';
+import { config } from '$lib/translations';
+
+export const load = async ({ data, url }) => {
+  const i18n = new I18n({ ...config, translations: data.translations });
+
+  await i18n.loadTranslations(data.locale, url.pathname);
+
+  return { i18n };
+};
+```
+
+What the payload leaves out:
+
+- **Other locales** — only the active locale and the fallback are serialized.
+- **Other routes** — a key claimed *only* by loaders whose `routes` do not match
+  the current route is dropped; the client loads it when it navigates there. A
+  key no loader claims (added through `addTranslations()`) is always kept.
+
+The data is **pre-preprocess** — the [`rawTranslations`](#translations--rawtranslations)
+shape — so the receiving instance applies its own `config.preprocess`.
+Freshness is not transferred either: the [`cache`](#cache) window of a hydrated
+locale starts when the client receives the data, not when the server loaded it.
+
+---
+
 ### `invalidate(locale?)`
 
 **Type:** `(locale?: string) => void`

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Complete API reference for `@sveltekit-i18n/base`. This package provides core i1
 
 - [Configuration](#configuration)
 - [Instance Properties and Methods](#instance-properties-and-methods)
+- [Server-Side Rendering](#server-side-rendering)
 - [Utilities](#utilities)
 - [TypeScript](#typescript)
 - [See Also](#see-also)
@@ -328,6 +329,9 @@ const config = {
 **Type:** `Translations.T` (optional)
 
 Synchronous translations that are available immediately, before any loaders execute.
+
+Locale keys are normalized the way [`sanitizeLocales()`](#sanitizelocaleslocales)
+normalizes them, so `EN` and `en` are one entry — the one `t()` reads.
 
 **Use Cases:**
 - Language names (same across all locales)
@@ -913,7 +917,8 @@ updates when either changes. Outside templates it is an ordinary function call.
 **Type:** `(locale: string, key: string, ...params: ParserParams) => ParserOutput`
 
 Like `t`, for an explicit locale — useful for rendering a language switcher in
-each language's own name.
+each language's own name. The locale is normalized before the lookup, so
+`l('EN', ...)` and `l('en', ...)` read the same table.
 
 ---
 
@@ -992,8 +997,10 @@ gate the first render:
 **Type:** `Record<string, Record<string, any>>` (reactive)
 
 The locale-indexed tables — `rawTranslations` before preprocessing,
-`translations` after. Treat them as read-only; use `addTranslations()` to
-write.
+`translations` after. Indexed by the normalized locale
+([`sanitizeLocales()`](#sanitizelocaleslocales)), the same value
+[`locale`](#locale) reports. Treat them as read-only; use `addTranslations()`
+to write.
 
 ---
 
@@ -1002,7 +1009,7 @@ write.
 **Type:** `(locale: string, route?: string) => Promise<void>`
 
 Loads translations for a locale and route, and activates the locale once they
-resolved. The canonical SSR wiring:
+resolved.
 
 ```javascript
 // +layout.js
@@ -1013,6 +1020,10 @@ export const load = async ({ url }) => {
   return {};
 };
 ```
+
+The instance above is a module-level singleton, which on the server is shared
+by every request in the process — see
+[Server-Side Rendering](#server-side-rendering) for the per-request wiring.
 
 **Errors:** a loader that throws is caught and logged individually, so one
 broken loader does not fail the batch. Anything that throws afterwards — a
@@ -1059,7 +1070,9 @@ the rejection.
 
 Adds translations synchronously (static tables known ahead of time). Payload is
 preprocessed per `config.preprocess` and merged into the tables; already-added
-keys count as loaded, so matching loaders will not refire.
+keys count as loaded, so matching loaders will not refire. Locale keys are
+normalized ([`sanitizeLocales()`](#sanitizelocaleslocales)) before they are
+merged.
 
 ```javascript
 i18n.addTranslations({
@@ -1177,6 +1190,124 @@ Call it when a per-request or per-component instance goes out of scope:
 
 A module-level singleton lives as long as the app and needs no call. The method
 is idempotent — calling it twice is a no-op.
+
+---
+
+## Server-Side Rendering
+
+A module that creates an instance is evaluated **once per process** on the
+server, not once per request. A module-level singleton is therefore shared by
+every visitor being rendered concurrently: two requests for different locales
+overwrite each other's `locale` and translation tables, and one visitor's
+language can end up in another visitor's HTML.
+
+Create **one instance per request** instead, and hand its data to the client
+with [`snapshot()`](#snapshot).
+
+### 1. Export the config, not the instance
+
+```javascript
+// src/lib/translations/index.js
+import parser from '@sveltekit-i18n/parser-default';
+
+/** @type {import('@sveltekit-i18n/base').Config} */
+export const config = {
+  parser: parser(),
+  loaders: [/* ... */],
+};
+```
+
+### 2. Load on the server, per request
+
+```javascript
+// src/routes/+layout.server.js
+import { I18n } from '@sveltekit-i18n/base';
+import { config } from '$lib/translations';
+
+export const load = async ({ url, locals }) => {
+  const i18n = new I18n(config);
+
+  await i18n.loadTranslations(locals.locale, url.pathname);
+
+  return { locale: locals.locale, translations: i18n.snapshot() };
+};
+```
+
+`locals.locale` is whatever your `handle` hook resolved from the cookie, the URL
+or the `Accept-Language` header — [`sanitizeLocales()`](#sanitizelocaleslocales)
+normalizes such a value the way the instance does.
+
+### 3. Build the instance the app renders with
+
+```javascript
+// src/routes/+layout.js
+import { browser } from '$app/environment';
+import { I18n } from '@sveltekit-i18n/base';
+import { config } from '$lib/translations';
+
+// Assigned in the browser only — on the server this module-level binding
+// would be the shared state we are avoiding.
+let client;
+
+export const load = async ({ data, url }) => {
+  const i18n = client ?? new I18n({ ...config, translations: data.translations });
+
+  if (browser) client = i18n;
+
+  await i18n.loadTranslations(data.locale, url.pathname);
+
+  return { i18n };
+};
+```
+
+This `load` runs on the server for the SSR pass and again in the browser on
+hydration. Both start from the server's snapshot, so the loaders behind it do
+not run a second time; only data the snapshot left out — the route-scoped
+translations of pages the visitor has not opened yet — is fetched. Every later
+client-side navigation reuses the same instance, so its cache survives.
+
+### 4. Pass it down through context
+
+```svelte
+<!-- src/routes/+layout.svelte -->
+<script>
+  import { setContext } from 'svelte';
+
+  let { data, children } = $props();
+
+  setContext('i18n', data.i18n);
+</script>
+
+{@render children()}
+```
+
+```svelte
+<!-- any component -->
+<script>
+  import { getContext } from 'svelte';
+
+  const i18n = getContext('i18n');
+</script>
+
+<p>{i18n.t('common.greeting')}</p>
+```
+
+The instance is reactive, so components re-render on a locale change without
+any store subscription.
+
+### When a singleton is enough
+
+The shared-state problem exists only on the server. A module-level instance is
+safe when the server renders nothing visitor-specific:
+
+- the app is client-only (`export const ssr = false`), or
+- every request renders the same locale.
+
+Then the [Quick Start](../README.md#quick-start) wiring — one
+`export const i18n = new I18n(config)` imported wherever it is needed — is all
+you need. An instance with a shorter life than the app (a per-request one, or a
+component-scoped one) should be released with [`destroy()`](#destroy) when its
+owner goes away.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1149,6 +1149,37 @@ refresh before the window elapses.
 
 ---
 
+### `destroy()`
+
+**Type:** `() => void`
+
+Detaches the instance from its loading lifecycle. Loads still in flight settle
+with their data discarded, [`loading`](#loading) drops to `false`, and every
+further load or mutation call (`loadTranslations`, `setLocale`, `setRoute`,
+`loadConfig`, `addTranslations`, `invalidate`) is ignored with a warning.
+
+Reads keep working — `t`, `l`, `locale`, `translations` and `snapshot()` still
+return the instance's last state, so a component that is still tearing down
+renders instead of breaking.
+
+Call it when a per-request or per-component instance goes out of scope:
+
+```svelte
+<script>
+  import { I18n } from '@sveltekit-i18n/base';
+  import { config } from '$lib/translations';
+
+  const i18n = new I18n(config);
+
+  $effect(() => () => i18n.destroy());
+</script>
+```
+
+A module-level singleton lives as long as the app and needs no call. The method
+is idempotent — calling it twice is a no-op.
+
+---
+
 ## Utilities
 
 Two helpers the instance uses internally are published separately, for the

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -37,6 +37,8 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
   /** In-flight loads keyed by locale and route; duplicate triggers share the promise. */
   #inflight = new Map<string, Promise<void>>();
 
+  #destroyed = false;
+
   constructor(config?: Config.T<ParserParams, ParserOutput>) {
     if (config) void this.loadConfig(config);
 
@@ -182,6 +184,8 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
    * unhandled rejection; an awaiting caller still receives it.
    */
   loadConfig = (config: Config.T<ParserParams, ParserOutput>) => {
+    if (this.#inert('loadConfig')) return Promise.resolve();
+
     const promise = this.configLoader(config);
 
     promise.catch((error) => logError('Failed to load the i18n config.', error));
@@ -192,7 +196,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
   // -- loading ----------------------------------------------------------------
 
   setLocale = (locale?: Config.Locale): Promise<void> => {
-    if (!locale) return Promise.resolve();
+    if (!locale || this.#inert('setLocale')) return Promise.resolve();
 
     if (locale !== this.#requestedLocale) {
       logger.debug(`Setting '${locale}' locale.`);
@@ -208,6 +212,8 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
   };
 
   setRoute = (route: string): Promise<void> => {
+    if (this.#inert('setRoute')) return Promise.resolve();
+
     if (route !== this.#route) {
       logger.debug(`Setting '${route}' route.`);
 
@@ -220,7 +226,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
   };
 
   loadTranslations = (locale: Config.Locale, route = this.#route ?? ''): Promise<void> => {
-    if (!locale) return Promise.resolve();
+    if (!locale || this.#inert('loadTranslations')) return Promise.resolve();
 
     this.#requestedLocale = locale;
     this.#route = route;
@@ -236,6 +242,8 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
    * discarded — it predates the invalidation.
    */
   invalidate = (locale?: Config.Locale): void => {
+    if (this.#inert('invalidate')) return;
+
     if (locale !== undefined) {
       const [sanitized] = sanitizeLocales(locale);
 
@@ -260,6 +268,8 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
   };
 
   addTranslations = (translations?: Translations.SerializedTranslations): void => {
+    if (this.#inert('addTranslations')) return;
+
     this.#addTranslations(translations);
   };
 
@@ -299,6 +309,26 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
 
       return { ...acc, [locale]: relevant };
     }, {});
+  };
+
+  /**
+   * Detaches the instance from its loading lifecycle: in-flight loads settle
+   * with their data discarded, `loading` drops to `false`, and every further
+   * load or mutation call is ignored with a warning. Reads (`t`, `l`, `locale`,
+   * `translations`, `snapshot`) keep working, so a component still tearing down
+   * renders its last state instead of breaking. Idempotent.
+   */
+  destroy = (): void => {
+    if (this.#destroyed) return;
+
+    logger.debug('Destroying the i18n instance.');
+
+    this.#destroyed = true;
+
+    // Severed rather than awaited — the identity guard in `#load` makes a
+    // settled load apply nothing once its entry is gone.
+    this.#inflight.clear();
+    this.#pending = new Set();
   };
 
   // -- internals --------------------------------------------------------------
@@ -408,6 +438,15 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
       // loads (other routes) must not extend the window.
       if (read(this.#loadedAt, locale) === undefined) this.#loadedAt[locale] = Date.now();
     });
+  }
+
+  /** Reports a call on a destroyed instance; `true` means "ignore the call". */
+  #inert(action: string): boolean {
+    if (!this.#destroyed) return false;
+
+    logger.warn(`Ignoring '${action}' — this i18n instance was destroyed.`);
+
+    return true;
   }
 
   #resolveLocale(inputLocale?: Config.Locale): Config.Locale | undefined {

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -1,4 +1,4 @@
-import { fetchTranslations, hasOwn, read, sanitizeLocales, testRoute, toDotNotation, translate } from './utils.js';
+import { fetchTranslations, hasOwn, read, sanitizeLocales, sanitizeTranslationLocales, testRoute, toDotNotation, translate } from './utils.js';
 import { logError, logger, loggerFactory, setLogger } from './logger.js';
 
 import type { Config, Extension, Loader, Parser, Translations } from './types.js';
@@ -113,12 +113,14 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
   l: Translations.LocalTranslationFunction<ParserParams, ParserOutput> = (locale, key, ...params) => {
     const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams, ParserOutput>;
 
+    const [sanitizedLocale = locale] = sanitizeLocales(locale);
+
     return translate<ParserParams, ParserOutput>({
       parser,
       key,
       params,
       translations: this.#translations,
-      locale,
+      locale: sanitizedLocale,
       fallbackLocale,
       ...(hasOwn(rest, 'fallbackValue') ? { fallbackValue: rest.fallbackValue } : {}),
     });
@@ -261,6 +263,44 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     this.#addTranslations(translations);
   };
 
+  /**
+   * Serializes what this instance holds for the active locale and the fallback
+   * locale, narrowed to the current route: a key owned only by loaders that do
+   * not match the route is left out. The result is shaped like
+   * `config.translations`, so a client hydrates by handing it back to the
+   * constructor — the bookkeeping derived from it then keeps the matching
+   * loaders from fetching the same data again.
+   */
+  snapshot = (): Translations.SerializedTranslations => {
+    const { fallbackLocale } = this.#config ?? {};
+
+    const route = this.#route ?? '';
+
+    // `#locale` is already sanitized; the fallback is normalized the same way
+    // the loaders key their data.
+    const locales = [this.#locale, ...sanitizeLocales(fallbackLocale)].filter((locale): locale is Config.Locale => !!locale);
+
+    return locales.reduce<Translations.SerializedTranslations>((acc, locale) => {
+      if (hasOwn(acc, locale)) return acc;
+
+      const data = read(this.#rawTranslations, locale);
+
+      if (!data) return acc;
+
+      const offRoute = this.#offRouteKeys(locale, route);
+
+      const relevant = Object.keys(data)
+        .filter((key) => !offRoute.has(key))
+        .reduce((keep, key) => ({ ...keep, [key]: read(data, key) }), {});
+
+      // An empty entry would still stamp the locale's freshness on the client,
+      // starting its `cache` window on data it never received.
+      if (!Object.keys(relevant).length) return acc;
+
+      return { ...acc, [locale]: relevant };
+    }, {});
+  };
+
   // -- internals --------------------------------------------------------------
 
   /**
@@ -314,14 +354,16 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
 
     logger.debug('Adding translations...');
 
-    const translationLocales = Object.keys(translations);
+    const sanitized = sanitizeTranslationLocales(translations);
+
+    const translationLocales = Object.keys(sanitized);
 
     this.#rawTranslations = translationLocales.reduce(
       (acc, locale) => ({
         ...acc,
         [locale]: {
           ...(read(acc, locale) || {}),
-          ...read(translations, locale),
+          ...read(sanitized, locale),
         },
       }),
       this.#rawTranslations,
@@ -330,7 +372,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     this.#translations = translationLocales.reduce(
       (acc, locale) => {
         let dotnotate = true;
-        let input = read(translations, locale);
+        let input = read(sanitized, locale);
 
         if (typeof preprocess === 'function') {
           input = preprocess(input);
@@ -354,7 +396,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     translationLocales.forEach((locale) => {
       // A `null` payload for a locale must not take the whole call down —
       // every step above tolerates it, so this bookkeeping does too.
-      let localeKeys: Loader.Key[] | undefined = Object.keys(read(translations, locale) ?? {}).map((key) => `${key}`.split('.')[0]);
+      let localeKeys: Loader.Key[] | undefined = Object.keys(read(sanitized, locale) ?? {}).map((key) => `${key}`.split('.')[0]);
       if (keys) localeKeys = read(keys, locale);
 
       this.#loadedKeys[locale] = Array.from(new Set([
@@ -426,6 +468,28 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     if (requested !== undefined && requested !== locale) return;
 
     if (this.#locale !== locale) this.#locale = locale;
+  }
+
+  /**
+   * Loader keys of `sanitizedLocale` that only ever load on OTHER routes. A key
+   * claimed by a route-matching loader — or by no loader at all — is not
+   * attributable to another route and is therefore absent here.
+   */
+  #offRouteKeys(sanitizedLocale: Config.Locale, route: string): Set<Loader.Key> {
+    const { loaders = [] } = this.#config ?? {};
+
+    const offRoute = new Set<Loader.Key>();
+    const onRoute = new Set<Loader.Key>();
+
+    loaders.forEach(({ key, locale, routes }) => {
+      if (sanitizeLocales(locale)[0] !== sanitizedLocale) return;
+
+      (routes && !routes.some(testRoute(route)) ? offRoute : onRoute).add(key);
+    });
+
+    onRoute.forEach((key) => offRoute.delete(key));
+
+    return offRoute;
   }
 
   #filterLoaders(sanitizedLocale: Config.Locale, route: string): Loader.LoaderModule[] {

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -1,4 +1,4 @@
-import { fetchTranslations, hasOwn, read, sanitizeLocales, sanitizeTranslationLocales, testRoute, toDotNotation, translate } from './utils.js';
+import { fetchTranslations, hasOwn, read, sanitizerFactory, sanitizeTranslationLocales, testRoute, toDotNotation, translate } from './utils.js';
 import { logError, logger, loggerFactory, setLogger } from './logger.js';
 
 import type { Config, Extension, Loader, Parser, Translations } from './types.js';
@@ -24,6 +24,9 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
 
   /** Replaced immutably on every change so `loading` recomputes. */
   #pending = $state<ReadonlySet<Promise<void>>>(new Set());
+
+  /** Locale normalization, as `config.sanitizeLocales` asks for it. */
+  #sanitize = $derived(sanitizerFactory(this.#config?.sanitizeLocales));
 
   // -- plain internal state ---------------------------------------------------
 
@@ -83,8 +86,8 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     const translationLocales = Object.keys(this.#translations);
 
     return Array.from(new Set([
-      ...sanitizeLocales(...loaderLocales),
-      ...sanitizeLocales(...translationLocales),
+      ...this.#sanitize(...loaderLocales),
+      ...this.#sanitize(...translationLocales),
     ]));
   });
 
@@ -115,7 +118,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
   l: Translations.LocalTranslationFunction<ParserParams, ParserOutput> = (locale, key, ...params) => {
     const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams, ParserOutput>;
 
-    const [sanitizedLocale = locale] = sanitizeLocales(locale);
+    const [sanitizedLocale = locale] = this.#sanitize(locale);
 
     return translate<ParserParams, ParserOutput>({
       parser,
@@ -146,8 +149,10 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
 
     if (log) setLogger(loggerFactory(log));
 
-    const [sanitizedInitLocale] = sanitizeLocales(initLocale);
-    const [sanitizedFallbackLocale] = sanitizeLocales(fallbackLocale);
+    const sanitize = sanitizerFactory(rest.sanitizeLocales);
+
+    const [sanitizedInitLocale] = sanitize(initLocale);
+    const [sanitizedFallbackLocale] = sanitize(fallbackLocale);
 
     logger.debug('Setting config.');
 
@@ -245,7 +250,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     if (this.#inert('invalidate')) return;
 
     if (locale !== undefined) {
-      const [sanitized] = sanitizeLocales(locale);
+      const [sanitized] = this.#sanitize(locale);
 
       if (sanitized !== undefined) {
         delete this.#loadedKeys[sanitized];
@@ -288,7 +293,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
 
     // `#locale` is already sanitized; the fallback is normalized the same way
     // the loaders key their data.
-    const locales = [this.#locale, ...sanitizeLocales(fallbackLocale)].filter((locale): locale is Config.Locale => !!locale);
+    const locales = [this.#locale, ...this.#sanitize(fallbackLocale)].filter((locale): locale is Config.Locale => !!locale);
 
     return locales.reduce<Translations.SerializedTranslations>((acc, locale) => {
       if (hasOwn(acc, locale)) return acc;
@@ -344,7 +349,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
   ): Promise<[Translations.SerializedTranslations, Loader.IndexedKeys] | []> {
     if (!this.#config || !locale) return [];
 
-    const [sanitizedLocale] = sanitizeLocales(locale);
+    const [sanitizedLocale] = this.#sanitize(locale);
     const filteredLoaders = this.#filterLoaders(sanitizedLocale, route);
 
     if (!filteredLoaders.length) return [];
@@ -384,7 +389,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
 
     logger.debug('Adding translations...');
 
-    const sanitized = sanitizeTranslationLocales(translations);
+    const sanitized = sanitizeTranslationLocales(translations, this.#sanitize);
 
     const translationLocales = Object.keys(sanitized);
 
@@ -463,7 +468,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     if (!all.length) return undefined;
 
     // Sanitized once per lookup rather than once per candidate locale.
-    const sanitized = sanitizeLocales(locale);
+    const sanitized = this.#sanitize(locale);
 
     const match = all.find((known) => sanitized.includes(known));
 
@@ -471,7 +476,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
 
     // Evaluated lazily: the fallback (and any non-standard warning it emits)
     // must not run when the requested locale resolves directly.
-    const sanitizedFallback = sanitizeLocales(fallbackLocale);
+    const sanitizedFallback = this.#sanitize(fallbackLocale);
 
     return all.find((known) => sanitizedFallback.includes(known));
   }
@@ -521,7 +526,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     const onRoute = new Set<Loader.Key>();
 
     loaders.forEach(({ key, locale, routes }) => {
-      if (sanitizeLocales(locale)[0] !== sanitizedLocale) return;
+      if (this.#sanitize(locale)[0] !== sanitizedLocale) return;
 
       (routes && !routes.some(testRoute(route)) ? offRoute : onRoute).add(key);
     });
@@ -534,13 +539,13 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
   #filterLoaders(sanitizedLocale: Config.Locale, route: string): Loader.LoaderModule[] {
     const { loaders, fallbackLocale = '' } = this.#config ?? {};
 
-    const [sanitizedFallbackLocale] = sanitizeLocales(fallbackLocale);
+    const [sanitizedFallbackLocale] = this.#sanitize(fallbackLocale);
 
     const translationForLocale = read(this.#translations, sanitizedLocale);
     const translationForFallbackLocale = read(this.#translations, sanitizedFallbackLocale);
 
     return (loaders || [])
-      .map(({ locale, ...rest }) => ({ ...rest, locale: sanitizeLocales(locale)[0] }))
+      .map(({ locale, ...rest }) => ({ ...rest, locale: this.#sanitize(locale)[0] }))
       .filter(({ routes }) => !routes || (routes || []).some(testRoute(route)))
       .filter(({ key, locale }) => (locale === sanitizedLocale && (
         !translationForLocale || !(read<Loader.Key[]>(this.#loadedKeys, sanitizedLocale) || []).includes(key)
@@ -567,7 +572,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     // Expiry is evaluated per load trigger, BEFORE the in-flight check. That
     // order is safe: a locale is stamped only once its data arrived, so a
     // shared in-flight load cannot be invalidated by its own duplicates.
-    this.#invalidateExpired(locale, sanitizeLocales(this.#config?.fallbackLocale)[0]);
+    this.#invalidateExpired(locale, this.#sanitize(this.#config?.fallbackLocale)[0]);
 
     // NUL never appears in a sanitized locale, so the key is unambiguous.
     const inflightKey = `${locale}\u0000${route}`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,8 @@ export namespace Config {
 
   export type FallbackValue = any;
 
+  export type SanitizeLocales = boolean | ((locale: Locale) => Locale);
+
   export type T<P extends Parser.Params = Parser.Params, O = Parser.Output> = {
     /**
      * You can use loaders to define your asyncronous translation load. All loaded data are stored so loader is triggered only once – in case there is no previous version of the translation. It can get triggered again once the `config.cache` window elapses, or after `invalidate()` is called.
@@ -77,6 +79,21 @@ export namespace Config {
      * By default, translation key is returned in case no translation is found for given translation key. For example, `$t('unknown.key')` will result in `'unknown.key'` output. You can set this output value using this config prop.
      */
     fallbackValue?: FallbackValue;
+    /**
+     * Defines how locale identifiers are normalized before they key anything – `config.translations`, loaders, the translation tables, `locale`, `fallbackLocale` and every locale you pass in. `true` normalizes to the ISO form, `false` keeps each locale exactly as it was authored, and a function normalizes it your way.
+     *
+     * @default true
+     *
+     * @example true
+     * 'en-us' => 'en-US'
+     *
+     * @example false
+     * 'en-us' => 'en-us'
+     *
+     * @example (locale) => locale.toLowerCase()
+     * 'en-US' => 'en-us'
+     */
+    sanitizeLocales?: SanitizeLocales;
     /**
      * Preprocessor strategy or a custom function. Defines, how to transform the translation data immediately after the load. Note that a custom function (like `'none'`) bypasses the dot-notation flattening entirely – its return value is stored as-is, so keys are then looked up exactly as the function produced them.
      * @default 'full'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -129,6 +129,18 @@ export const sanitizeLocales = (...locales: any[]) => {
   });
 };
 
+// Every other locale-keyed surface (`locale`, `fallbackLocale`, loader data,
+// the loaded-key bookkeeping) is sanitized, so a table handed in under a raw
+// locale would be unreachable. Merged rather than replaced: two spellings of
+// one locale are one entry.
+export const sanitizeTranslationLocales = (input: Translations.SerializedTranslations): Translations.SerializedTranslations => (
+  Object.keys(input).reduce<Translations.SerializedTranslations>((acc, locale) => {
+    const [sanitized = locale] = sanitizeLocales(locale);
+
+    return { ...acc, [sanitized]: { ...read(acc, sanitized), ...read(input, locale) } };
+  }, {})
+);
+
 export const toDotNotation: DotNotation.T = (input, preserveArrays, parentKey) => {
   if (preserveArrays && Array.isArray(input)) {
     return input.map((v) => toDotNotation(v, preserveArrays));
@@ -171,13 +183,10 @@ export const serialize = (input: Array<Loader.LoaderModule & { data: any }>) => 
   return input.reduce((acc, { key, data, locale }) => {
     if (!data) return acc;
 
-    const [validLocale] = sanitizeLocales(locale);
-
-    const output = { ...(acc[validLocale] || {}), [key]: data };
-
+    // The locale is already sanitized — loaders are normalized before the fetch.
     return ({
       ...acc,
-      [validLocale]: output,
+      [locale]: { ...read(acc, locale), [key]: data },
     });
   }, {} as Translations.SerializedTranslations);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,46 +96,77 @@ const rememberSanitizedLocale = (locale: string, sanitized: string) => {
   sanitizedLocaleCache.set(locale, sanitized);
 };
 
-export const sanitizeLocales = (...locales: any[]) => {
+type Sanitizer = (...locales: any[]) => Config.Locale[];
+
+const mapLocales = (transform: (locale: any) => Config.Locale): Sanitizer => (...locales) => {
   if (!locales.length) return [];
 
-  return locales.filter((locale) => !!locale).map((locale) => {
-    // Only a string is a faithful key for itself.
-    const cacheable = typeof locale === 'string';
+  return locales.filter((locale) => !!locale).map(transform);
+};
 
-    if (cacheable) {
-      const cached = recallSanitizedLocale(locale);
+export const sanitizeLocales = mapLocales((locale) => {
+  // Only a string is a faithful key for itself.
+  const cacheable = typeof locale === 'string';
 
-      if (cached !== undefined) return cached;
-    }
+  if (cacheable) {
+    const cached = recallSanitizedLocale(locale);
 
-    let current = `${locale}`.toLowerCase();
-    try {
-      const [sanitized] = Intl.Collator.supportedLocalesOf(locale);
+    if (cached !== undefined) return cached;
+  }
 
-      if (!sanitized) throw new Error();
+  let current = `${locale}`.toLowerCase();
+  try {
+    const [sanitized] = Intl.Collator.supportedLocalesOf(locale);
 
-      current = sanitized;
+    if (!sanitized) throw new Error();
 
-      if (cacheable) rememberSanitizedLocale(locale, current);
-    } catch {
-      // Deliberately not remembered: a locale Intl does not know yet can
-      // recover, and the warning stays tied to the call rather than to
-      // whichever logger was installed first.
-      logger.warn(`'${locale}' locale is non-standard.`);
-    }
+    current = sanitized;
 
-    return current;
-  });
+    if (cacheable) rememberSanitizedLocale(locale, current);
+  } catch {
+    // Deliberately not remembered: a locale Intl does not know yet can
+    // recover, and the warning stays tied to the call rather than to
+    // whichever logger was installed first.
+    logger.warn(`'${locale}' locale is non-standard.`);
+  }
+
+  return current;
+});
+
+// The normalization `config.sanitizeLocales` asks for. A custom transform is
+// consumer code and every table is keyed by what it returns, so a throwing or
+// empty-handed one degrades to the locale as authored.
+export const sanitizerFactory = (sanitize: Config.SanitizeLocales = true): Sanitizer => {
+  if (typeof sanitize === 'function') {
+    return mapLocales((locale) => {
+      const input: Config.Locale = `${locale}`;
+
+      try {
+        const transformed = sanitize(input);
+
+        if (transformed) return `${transformed}`;
+
+        logger.warn(`'sanitizeLocales' returned no locale for '${input}'.`);
+      } catch (error) {
+        logError(`'sanitizeLocales' failed for '${input}' locale.`, error);
+      }
+
+      return input;
+    });
+  }
+
+  if (!sanitize) return mapLocales((locale) => `${locale}`);
+
+  return sanitizeLocales;
 };
 
 // Every other locale-keyed surface (`locale`, `fallbackLocale`, loader data,
 // the loaded-key bookkeeping) is sanitized, so a table handed in under a raw
 // locale would be unreachable. Merged rather than replaced: two spellings of
 // one locale are one entry.
-export const sanitizeTranslationLocales = (input: Translations.SerializedTranslations): Translations.SerializedTranslations => (
+export const sanitizeTranslationLocales = (input: Translations.SerializedTranslations, sanitize: Sanitizer): Translations.SerializedTranslations => (
   Object.keys(input).reduce<Translations.SerializedTranslations>((acc, locale) => {
-    const [sanitized = locale] = sanitizeLocales(locale);
+    const [sanitized = locale] = sanitize(locale);
 
     return { ...acc, [sanitized]: { ...read(acc, sanitized), ...read(input, locale) } };
   }, {})

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -32,6 +32,7 @@ describe('i18n instance', () => {
     expect(instance).toHaveProperty('setRoute');
     expect(instance).toHaveProperty('invalidate');
     expect(instance).toHaveProperty('snapshot');
+    expect(instance).toHaveProperty('destroy');
     // The v2 SSR hand-off primitive is deleted from v3, not deprecated — pin
     // its absence so it cannot quietly return.
     expect(instance).not.toHaveProperty('getTranslationProps');
@@ -1223,6 +1224,89 @@ describe('i18n snapshot', () => {
     await client.setRoute('/about');
     expect(calls).toEqual({ about: 1 });
     expect(client.t('about.title')).toBe('About');
+  });
+});
+
+describe('i18n destroy', () => {
+  const valueParser = { parse: (text: any, _params: any, _locale: any, key: string) => (text === undefined ? key : text) };
+
+  it('discards an in-flight load and clears the loading flag', async () => {
+    let calls = 0;
+    const resolvers: Array<(value: any) => void> = [];
+    const instance = new i18n({
+      parser: valueParser,
+      log,
+      loaders: [
+        { key: 'common', locale: 'en', loader: () => new Promise<any>((resolve) => { calls += 1; resolvers.push(resolve); }) },
+      ],
+    });
+
+    const pending = instance.loadTranslations('en', '/');
+    expect(instance.loading).toBe(true);
+
+    instance.destroy();
+    expect(instance.loading).toBe(false);
+
+    resolvers[0]?.({ greeting: 'late' });
+    await pending;
+
+    expect(calls).toBe(1);
+    expect(instance.rawTranslations).toEqual({});
+    expect(instance.locale).toBeUndefined();
+  });
+
+  it('ignores every further load and mutation', async () => {
+    let calls = 0;
+    const instance = new i18n({
+      parser: valueParser,
+      log,
+      loaders: [{ key: 'common', locale: 'en', loader: async () => { calls += 1; return { greeting: 'Hello' }; } }],
+    });
+
+    await instance.loadTranslations('en', '/');
+    expect(calls).toBe(1);
+
+    instance.destroy();
+
+    await instance.loadTranslations('en', '/about');
+    await instance.setLocale('cs');
+    await instance.setRoute('/about');
+    instance.invalidate();
+    instance.addTranslations({ en: { extra: { note: 'ignored' } } });
+
+    expect(calls).toBe(1);
+    expect(instance.locale).toBe('en');
+    expect(instance.rawTranslations.en).not.toHaveProperty('extra');
+  });
+
+  it('keeps reads working, so a tearing-down component still renders', async () => {
+    const instance = new i18n({
+      parser: valueParser,
+      log,
+      loaders: [{ key: 'common', locale: 'en', loader: async () => ({ greeting: 'Hello' }) }],
+    });
+
+    await instance.loadTranslations('en', '/');
+    instance.destroy();
+
+    expect(instance.t('common.greeting')).toBe('Hello');
+    expect(instance.l('en', 'common.greeting')).toBe('Hello');
+    expect(instance.snapshot()).toEqual({ en: { common: { greeting: 'Hello' } } });
+  });
+
+  it('is idempotent', async () => {
+    const instance = new i18n({
+      parser: valueParser,
+      log,
+      loaders: [{ key: 'common', locale: 'en', loader: async () => ({ greeting: 'Hello' }) }],
+    });
+
+    await instance.loadTranslations('en', '/');
+
+    instance.destroy();
+    instance.destroy();
+
+    expect(instance.t('common.greeting')).toBe('Hello');
   });
 });
 

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -653,6 +653,93 @@ describe('i18n locale keys', () => {
   });
 });
 
+describe('i18n sanitizeLocales config', () => {
+  const valueParser = { parse: (text: any, _params: any, _locale: any, key: string) => (text === undefined ? key : text) };
+
+  it('`false` keeps every locale exactly as it was authored', async () => {
+    const instance = new i18n({
+      parser: valueParser,
+      log,
+      sanitizeLocales: false,
+      initLocale: 'CS',
+      translations: { CS: { greeting: 'Ahoj' } },
+    });
+
+    await instance.loadTranslations('CS');
+
+    expect(instance.locale).toBe('CS');
+    expect(instance.locales).toEqual(['CS']);
+    expect(Object.keys(instance.translations)).toEqual(['CS']);
+    expect(instance.t('greeting')).toBe('Ahoj');
+    expect(instance.l('CS', 'greeting')).toBe('Ahoj');
+  });
+
+  it('`false` keeps spellings of one locale apart', () => {
+    const instance = new i18n({ parser: valueParser, log, sanitizeLocales: false });
+
+    instance.addTranslations({ CS: { greeting: 'Ahoj' }, cs: { farewell: 'Ahoj' } });
+
+    expect(instance.rawTranslations).toStrictEqual({ CS: { greeting: 'Ahoj' }, cs: { farewell: 'Ahoj' } });
+  });
+
+  it('a custom transform keys loaders, tables and the active locale', async () => {
+    let calls = 0;
+    const instance = new i18n({
+      parser: valueParser,
+      log,
+      sanitizeLocales: (locale) => locale.toUpperCase(),
+      loaders: [{ key: 'common', locale: 'en', loader: async () => { calls += 1; return { greeting: 'Hello' }; } }],
+    });
+
+    await instance.loadTranslations('en');
+
+    expect(calls).toBe(1);
+    expect(instance.locale).toBe('EN');
+    expect(instance.locales).toEqual(['EN']);
+    expect(Object.keys(instance.translations)).toEqual(['EN']);
+    expect(instance.t('common.greeting')).toBe('Hello');
+
+    // The bookkeeping is keyed through the same transform, so an authored
+    // locale reaches the entry the load created.
+    instance.invalidate('en');
+    await instance.loadTranslations('EN');
+
+    expect(calls).toBe(2);
+  });
+
+  it('normalizes `initLocale` and `fallbackLocale` the way the INCOMING config asks', async () => {
+    // They are normalized before the config is applied, so they must not be
+    // read through the strategy the instance is still configured with.
+    const instance = new i18n();
+
+    await instance.loadConfig({
+      parser: valueParser,
+      log,
+      sanitizeLocales: false,
+      initLocale: 'EN',
+      fallbackLocale: 'CS',
+      translations: { CS: { greeting: 'Ahoj' }, EN: { farewell: 'Ahoj' } },
+    });
+
+    expect(instance.locale).toBe('EN');
+    expect(instance.t('greeting')).toBe('Ahoj');
+  });
+
+  it('a throwing transform falls back to the locale as authored', async () => {
+    const instance = new i18n({
+      parser: valueParser,
+      log,
+      sanitizeLocales: () => { throw new Error('nope'); },
+      translations: { en: { greeting: 'Hello' } },
+    });
+
+    await expect(instance.loadTranslations('en')).resolves.toBeUndefined();
+
+    expect(instance.locale).toBe('en');
+    expect(instance.t('greeting')).toBe('Hello');
+  });
+});
+
 describe('i18n extensions', () => {
   it('constructs the plain instance when no extensions are configured', () => {
     // Assignability doubles as the type-level assertion: without extensions

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -31,6 +31,7 @@ describe('i18n instance', () => {
     expect(instance).toHaveProperty('setLocale');
     expect(instance).toHaveProperty('setRoute');
     expect(instance).toHaveProperty('invalidate');
+    expect(instance).toHaveProperty('snapshot');
     // The v2 SSR hand-off primitive is deleted from v3, not deprecated — pin
     // its absence so it cannot quietly return.
     expect(instance).not.toHaveProperty('getTranslationProps');
@@ -600,6 +601,57 @@ describe('i18n instance', () => {
   });
 });
 
+describe('i18n locale keys', () => {
+  const valueParser = { parse: (text: any, _params: any, _locale: any, key: string) => (text === undefined ? key : text) };
+
+  it('`addTranslations` normalizes the locale key so `t` reaches the data', async () => {
+    const instance = new i18n({ parser: valueParser, log, initLocale: 'EN', translations: { EN: { greeting: 'Hello' } } });
+
+    await instance.loadTranslations('EN');
+
+    expect(instance.locale).toBe('en');
+    expect(Object.keys(instance.translations)).toEqual(['en']);
+    expect(instance.t('greeting')).toBe('Hello');
+  });
+
+  it('`addTranslations` merges spellings that normalize to the same locale', () => {
+    const instance = new i18n({ parser: valueParser, log });
+
+    instance.addTranslations({ EN: { greeting: 'Hello' }, en: { farewell: 'Bye' } });
+
+    expect(instance.rawTranslations).toStrictEqual({ en: { greeting: 'Hello', farewell: 'Bye' } });
+  });
+
+  it('`l` reaches the table through a non-canonical locale', () => {
+    const instance = new i18n({ parser: valueParser, log, translations: { en: { greeting: 'Hello' } } });
+
+    expect(instance.l('EN', 'greeting')).toBe('Hello');
+  });
+
+  it('a non-canonical `config.translations` key still suppresses its loader', async () => {
+    let calls = 0;
+    const instance = new i18n({
+      parser: valueParser,
+      log,
+      translations: { EN: { common: { greeting: 'Hello' } } },
+      loaders: [{ key: 'common', locale: 'en', loader: async () => { calls += 1; return { greeting: 'Hello' }; } }],
+    });
+
+    await instance.loadTranslations('en');
+
+    expect(calls).toBe(0);
+    expect(instance.t('common.greeting')).toBe('Hello');
+  });
+
+  it('`snapshot` carries data added under a non-canonical locale', async () => {
+    const instance = new i18n({ parser: valueParser, log, translations: { EN: { common: { greeting: 'Hello' } } } });
+
+    await instance.loadTranslations('EN');
+
+    expect(instance.snapshot()).toEqual({ en: { common: { greeting: 'Hello' } } });
+  });
+});
+
 describe('i18n extensions', () => {
   it('constructs the plain instance when no extensions are configured', () => {
     // Assignability doubles as the type-level assertion: without extensions
@@ -1080,6 +1132,97 @@ describe('i18n cache and invalidation', () => {
 
     await instance.loadTranslations('en');
     expect(newCalls).toBe(1);
+  });
+});
+
+describe('i18n snapshot', () => {
+  const valueParser = { parse: (text: any, _params: any, _locale: any, key: string) => (text === undefined ? key : text) };
+
+  const countingLoaders = (calls: Record<string, number>) => [
+    { key: 'common', locale: 'en', loader: async () => { calls.common = (calls.common ?? 0) + 1; return { greeting: 'Hello' }; } },
+    { key: 'home', locale: 'en', routes: ['/'], loader: async () => { calls.home = (calls.home ?? 0) + 1; return { title: 'Home' }; } },
+    { key: 'about', locale: 'en', routes: ['/about'], loader: async () => { calls.about = (calls.about ?? 0) + 1; return { title: 'About' }; } },
+    { key: 'common', locale: 'cs', loader: async () => { calls.cs = (calls.cs ?? 0) + 1; return { greeting: 'Ahoj' }; } },
+  ];
+
+  it('returns nothing before anything loaded', () => {
+    const instance = new i18n({ parser: valueParser, log, loaders: countingLoaders({}) });
+
+    expect(instance.snapshot()).toEqual({});
+  });
+
+  it('narrows the active locale to the current route', async () => {
+    const instance = new i18n({ parser: valueParser, log, loaders: countingLoaders({}) });
+
+    await instance.loadTranslations('en', '/about');
+    await instance.setRoute('/');
+
+    // '/about' data is still held, but it belongs to another route — sending
+    // it would let the client hydrate keys its own loaders never claim back.
+    expect(instance.snapshot()).toEqual({
+      en: {
+        common: { greeting: 'Hello' },
+        home: { title: 'Home' },
+      },
+    });
+  });
+
+  it('keeps keys no loader claims', async () => {
+    const instance = new i18n({ parser: valueParser, log, loaders: countingLoaders({}) });
+
+    await instance.loadTranslations('en', '/');
+    instance.addTranslations({ en: { extra: { note: 'kept' } } });
+
+    expect(instance.snapshot().en).toHaveProperty('extra');
+  });
+
+  it('includes the fallback locale', async () => {
+    const instance = new i18n({ parser: valueParser, log, fallbackLocale: 'cs', loaders: countingLoaders({}) });
+
+    await instance.loadTranslations('en', '/');
+
+    expect(Object.keys(instance.snapshot()).sort()).toEqual(['cs', 'en']);
+  });
+
+  it('is pre-preprocess, so the receiving instance applies its own', async () => {
+    const instance = new i18n({ parser: valueParser, log, preprocess: 'none', loaders: countingLoaders({}) });
+
+    await instance.loadTranslations('en', '/');
+
+    // Nested, not dot-notated — `rawTranslations` shape, not `translations`.
+    expect(instance.snapshot().en.common).toEqual({ greeting: 'Hello' });
+  });
+
+  it('hydrates a fresh instance through `config.translations` without refetching', async () => {
+    const server = new i18n({ parser: valueParser, log, loaders: countingLoaders({}) });
+
+    await server.loadTranslations('en', '/');
+
+    const calls: Record<string, number> = {};
+    const client = new i18n({ parser: valueParser, log, translations: server.snapshot(), loaders: countingLoaders(calls) });
+
+    await client.loadTranslations('en', '/');
+
+    expect(calls).toEqual({});
+    expect(client.t('common.greeting')).toBe('Hello');
+    expect(client.t('home.title')).toBe('Home');
+  });
+
+  it('leaves the loaders of other routes to run on navigation', async () => {
+    const server = new i18n({ parser: valueParser, log, loaders: countingLoaders({}) });
+
+    await server.loadTranslations('en', '/about');
+    await server.setRoute('/');
+
+    const calls: Record<string, number> = {};
+    const client = new i18n({ parser: valueParser, log, translations: server.snapshot(), loaders: countingLoaders(calls) });
+
+    await client.loadTranslations('en', '/');
+    expect(calls).toEqual({});
+
+    await client.setRoute('/about');
+    expect(calls).toEqual({ about: 1 });
+    expect(client.t('about.title')).toBe('About');
   });
 });
 


### PR DESCRIPTION
## What

Adds the two lifecycle methods a per-request SSR instance needs, makes that pattern the documented SSR wiring, fixes a locale-key inconsistency that made the hand-off silently lose data, and makes the locale normalization itself configurable.

- **`snapshot()`** — serializes what the instance holds for the active locale and the `fallbackLocale`, narrowed to the current route, in the `config.translations` shape. The client hydrates by handing the payload back to the constructor.
- **`destroy()`** — severs in-flight loads (they settle applying nothing), drops `loading` to `false`, and makes every further load or mutation call a logged no-op. Reads stay live; idempotent.
- **Sanitized locale keys** — translation tables are now stored under the normalized locale, and `l()` normalizes the locale it is passed, so a table handed in as `{ EN: ... }` is reachable.
- **`config.sanitizeLocales`** — `true` (default) keeps the ISO normalization, `false` keeps every locale exactly as authored, and a function normalizes locales the app's own way.
- **Docs** — a new `Server-Side Rendering` section documents one instance per request (`+layout.server.js` → `snapshot()` → `+layout.js` → context); the module singleton stays as the shorthand for apps that render nothing visitor-specific, with an explicit warning in the Quick Start and in `loadTranslations()`.

## Why

Fixes sveltekit-i18n/lib#231
Fixes sveltekit-i18n/lib#106
Fixes sveltekit-i18n/lib#186
Fixes sveltekit-i18n/lib#81

A module that creates an instance is evaluated once per process on the server, so a module-level singleton is shared by every concurrently rendered request — one visitor&#39;s locale can land in another visitor&#39;s HTML (#106), and the server-side instance accumulates every client&#39;s translations, so the hand-off ships every other visitor&#39;s locales and every off-route key (#186). base#21 deleted the v2 `getTranslationProps()` hand-off, so 3.0 would otherwise ship with no SSR hand-off story at all.

The locale-key fix surfaced while documenting that hand-off. Every locale-keyed surface — `locale`, `config.fallbackLocale`, loader data, the loaded-key bookkeeping — is sanitized, but `addTranslations` stored incoming tables under the literal keys it was given and `l()` looked up the literal locale it was passed. A table handed in as `{ EN: ... }` therefore sat in memory unreachable: `t()` missed, the fallback path missed, the loader for that locale still ran, `snapshot()` skipped the locale and `invalidate(&#39;EN&#39;)` dropped nothing.

Making that normalization consistent everywhere also makes it inescapable, which is exactly what #81 asks not to be: an app that spells its locales its own way (`CS`, `en_US`) had no way to keep that spelling. `config.sanitizeLocales` is the opt-out.

## How

`snapshot()` reads `rawTranslations` (pre-preprocess, so the receiving instance applies its own `preprocess`) and drops keys claimed *only* by loaders whose `routes` do not match the current route; a key no loader claims — one added through `addTranslations()` — is always kept. A locale with nothing relevant is omitted entirely, so hydration cannot start a `cache` window on data the client never received.

No hydration counterpart is needed: `#addTranslations` already derives loaded-key bookkeeping from the data&#39;s top-level keys when no explicit keys are given, which is exactly what `config.translations` goes through. Freshness is stamped from the client&#39;s own clock, so no server timestamp travels with the payload.

`destroy()` reuses the existing in-flight severing mechanism — clearing the `#inflight` entry makes the identity guard in `#load` discard a settled load&#39;s data.

Locale keys are normalized inside the private `#addTranslations`, so the public method and the loader path share one owner, and `l()` sanitizes its locale argument before the lookup. Spellings that normalize to the same locale merge into one entry rather than overwriting each other. The new `sanitizeTranslationLocales` helper stays internal — the published `/utils` surface is unchanged — and writes through a computed-key spread, so a locale literally named `__proto__` remains an own property.

With that in place the sanitization inside `serialize()` is dead work: `#filterLoaders` normalizes every loader&#39;s locale before the fetch, and `serialize()` is reached only through `fetchTranslations()` on that path, so it re-derived a value it already had and re-emitted the non-standard-locale warning on every load. Removed rather than folded into the shared helper — the two are not the same operation. Its accumulator lookup moves to the own-property `read` helper at the same time, so a locale spelled like a prototype member reads as absent instead of inheriting from `Object.prototype`.

`config.sanitizeLocales` resolves through a `sanitizerFactory` and reaches the instance as one private `$derived` sanitizer that every locale-keyed surface calls, so all three strategies share the same call sites and the same mapper — a falsy-filtering map over the locale list. The exported `sanitizeLocales` utility keeps being the ISO strategy and keeps its LRU cache; a custom transform is uncached and documented as needing to be cheap and pure. Because the config load normalizes `initLocale` and `fallbackLocale` before `#config` is replaced, that step builds its sanitizer from the incoming config rather than reading the derived one — reading the derived one would normalize a new config&#39;s locales with the strategy the instance is still configured with. Per the fail-soft posture, a transform that throws or returns nothing degrades to the locale as authored and is reported through the logger.

## Testing

`npm run build`, `npm run lint`, `npm test` (107 passed), `npm run test:dist` (4 passed) — all green on the branch tip.

New coverage: route narrowing (data loaded on `/about` is excluded once the route is `/`), fallback-locale inclusion, unclaimed keys kept, pre-preprocess shape, hydration through `config.translations` firing no loader, off-route loaders still running on navigation; and for `destroy()`: in-flight discard, ignored mutations, live reads, idempotence.

For the locale-key fix: `t()` reaching data added as `{ EN: ... }`, `EN`/`en` merging into one entry, `l(&#39;EN&#39;, ...)` resolving, a non-canonical `config.translations` key suppressing its loader, and `snapshot()` carrying that data. All five were confirmed to fail against the unfixed code.

For `config.sanitizeLocales`: `false` keeping `CS` spelled as authored across `locales`, `translations`, `t()` and `l()`; `false` keeping `CS` and `cs` as two separate entries; a custom transform keying loaders, the tables, the active locale and the `invalidate()` bookkeeping alike; `initLocale` and `fallbackLocale` being normalized by the incoming config&#39;s strategy rather than the one still configured; and a throwing transform degrading to the locale as authored. All but the last were confirmed to fail against the unpatched source (the throwing case degrades to the same result either way).

Both route-narrowing tests were confirmed to fail against a build without the narrowing helper.

The `serialize()` cleanup is behavior-preserving on every reachable path and adds no test of its own; the existing suite covers it.

Markdown anchors in `README.md` and `docs/README.md` were validated programmatically.

## Checklist

- [x] **Tests pass locally** (`npm test`)
- [x] **Linter passes** (`npm run lint`)
- [x] **Build succeeds** (`npm run build`)
- [x] **All commits are atomic** (each commit works independently)
- [x] **Commits have clear messages** (imperative mood, descriptive)
- [x] **Branch rebased on latest master** (`git rebase origin/master`)
- [ ] **CHANGELOG.md updated** — the repository has no `CHANGELOG.md`; releases carry the notes
- [x] **Documentation updated** (if API or behavior changed)

## Notes

Out of scope, tracked separately:

- Parameterized-route cache identity — sveltekit-i18n/lib#233.
- The branch name is the one this environment mandates rather than the `feat/` form AGENTS.md §7 asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV

---
_Generated by [Claude Code](https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV)_