### PR TITLE
fix: survive unreadable loader descriptors, merge shared namespaces

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -117,10 +117,42 @@ config-time `logger.error` reports such keys, but the loader still runs):
   `loaders` wins and the collision is reported through the
   [logger](#loglevel).
 
-Merging applies to loaders that run together. A key is still loaded once per
-locale, so once one loader has supplied `common`, every loader declaring that
-key is skipped — splitting a namespace into `routes`-scoped chunks therefore
-keeps only the chunk whose route triggered the first load.
+**A key is loaded only once per locale.** Loaders sharing a key therefore merge
+only when they run in the same load — when their `routes` all match the route
+that triggered it:
+
+```javascript
+loaders: [
+  { locale: 'en', key: 'common', routes: ['/'], loader: async () => ({ menu: { home: 'Home' } }) },
+  { locale: 'en', key: 'common', loader: async () => ({ menu: { about: 'About' } }) },
+]
+// both loaders run when '/' is loaded
+// i18n.t('common.menu.home')  => 'Home'
+// i18n.t('common.menu.about') => 'About'
+```
+
+As soon as one loader has supplied `common`, every other `common` loader is
+skipped — including one that never had the chance to run, because its `routes`
+did not match.
+
+**⚠️ Common Pitfall:** Splitting one namespace into `routes`-scoped chunks. Give
+each route a key of its own instead:
+
+```javascript
+// ❌ Bad — a visitor landing on '/about' loads `common` from the second loader,
+// and moving to '/' no longer runs the first one
+loaders: [
+  { locale: 'en', key: 'common', routes: ['/'], loader: async () => ({ menu: { home: 'Home' } }) },
+  { locale: 'en', key: 'common', routes: ['/about'], loader: async () => ({ menu: { about: 'About' } }) },
+]
+// i18n.t('common.menu.home') => not loaded
+
+// ✅ Good
+loaders: [
+  { locale: 'en', key: 'home', routes: ['/'], loader: async () => ({ menu: { home: 'Home' } }) },
+  { locale: 'en', key: 'about', routes: ['/about'], loader: async () => ({ menu: { about: 'About' } }) },
+]
+```
 
 ##### `loader` (required)
 
@@ -1153,6 +1185,10 @@ Adds translations synchronously (static tables known ahead of time). Payload is
 preprocessed per `config.preprocess` and merged into the tables; already-added
 keys count as loaded, so matching loaders will not refire. Locale keys are
 normalized ([`sanitizeLocales`](#sanitizelocales)) before they are merged.
+
+Merging goes branch by branch, so a payload for a namespace that already holds
+data adds to it instead of replacing it; a leaf declared twice takes the
+incoming value.
 
 ```javascript
 i18n.addTranslations({

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,7 +84,6 @@ The locale identifier this loader is for (e.g., `'en'`, `'cs'`, `'de-DE'`).
 Translation namespace identifier. This acts as a prefix for translation keys.
 
 **Rules:**
-- Should be unique within a locale
 - Cannot contain dots (`.`)
 - Use descriptive names (`common`, `home`, `auth`, etc.)
 
@@ -108,6 +107,20 @@ config-time `logger.error` reports such keys, but the loader still runs):
 // ✅ Good
 { key: 'home' }
 ```
+
+**Sharing a key.** Several loaders may declare the same `locale` and `key`:
+
+- Their data is **merged** where they fill in different parts of the
+  namespace — every loader contributes its own branches.
+- A value is **replaced** where the same translation is declared twice (or one
+  loader's object meets another's string). The loader declared later in
+  `loaders` wins and the collision is reported through the
+  [logger](#loglevel).
+
+Merging applies to loaders that run together. A key is still loaded once per
+locale, so once one loader has supplied `common`, every loader declaring that
+key is skipped — splitting a namespace into `routes`-scoped chunks therefore
+keeps only the chunk whose route triggered the first load.
 
 ##### `loader` (required)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -275,6 +275,12 @@ it pure — a matcher may be consulted more than once per load:
 
 **💡 Tip:** Keep common translations small and use route-based loading for page-specific content to optimize performance.
 
+**Loader descriptors are read once.** `locale`, `key`, `loader` and `routes`
+are captured when the config is applied, so a property implemented as a getter
+is not re-evaluated on later loads. A descriptor that throws while being read
+is reported through the [logger](#loglevel) and dropped — the remaining loaders
+keep working, and [`locales`](#locales) lists the ones that resolved.
+
 #### Complete Loaders Example
 
 ```javascript

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -1,4 +1,4 @@
-import { fetchTranslations, hasOwn, read, resolveLoaders, sanitizerFactory, sanitizeTranslationLocales, testRoute, toDotNotation, translate } from './utils.js';
+import { fetchTranslations, hasOwn, mergeTranslations, read, resolveLoaders, sanitizerFactory, sanitizeTranslationLocales, testRoute, toDotNotation, translate } from './utils.js';
 import { logError, logger, loggerFactory, setLogger } from './logger.js';
 
 import type { Config, Extension, Loader, Parser, Translations } from './types.js';
@@ -399,10 +399,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     this.#rawTranslations = translationLocales.reduce(
       (acc, locale) => ({
         ...acc,
-        [locale]: {
-          ...(read(acc, locale) || {}),
-          ...read(sanitized, locale),
-        },
+        [locale]: mergeTranslations(read(acc, locale) || {}, read(sanitized, locale) ?? {}, locale),
       }),
       this.#rawTranslations,
     );
@@ -422,10 +419,11 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
 
         return ({
           ...acc,
-          [locale]: {
-            ...(read(acc, locale) || {}),
-            ...(dotnotate ? toDotNotation(input, preprocess === 'preserveArrays') : input),
-          },
+          [locale]: mergeTranslations(
+            read(acc, locale) || {},
+            (dotnotate ? toDotNotation(input, preprocess === 'preserveArrays') : input) ?? {},
+            locale,
+          ),
         });
       },
       this.#translations,

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -1,4 +1,4 @@
-import { fetchTranslations, hasOwn, read, sanitizerFactory, sanitizeTranslationLocales, testRoute, toDotNotation, translate } from './utils.js';
+import { fetchTranslations, hasOwn, read, resolveLoaders, sanitizerFactory, sanitizeTranslationLocales, testRoute, toDotNotation, translate } from './utils.js';
 import { logError, logger, loggerFactory, setLogger } from './logger.js';
 
 import type { Config, Extension, Loader, Parser, Translations } from './types.js';
@@ -154,6 +154,8 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
     const [sanitizedInitLocale] = sanitize(initLocale);
     const [sanitizedFallbackLocale] = sanitize(fallbackLocale);
 
+    const loaders = resolveLoaders(rest.loaders);
+
     logger.debug('Setting config.');
 
     this.#config = {
@@ -161,13 +163,14 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
       fallbackLocale: sanitizedFallbackLocale,
       translations,
       ...rest,
+      loaders,
     };
 
     // Report-only: the loader still runs, but `.` is the dot-notation
     // separator, so a dotted key collides with the flattened namespace.
     // `String` rather than a template literal — interpolating a Symbol throws,
     // and a config-time report must not abort the rest of the config load.
-    (rest.loaders ?? []).forEach(({ key }) => {
+    loaders.forEach(({ key }) => {
       const name = key == null ? '' : String(key);
 
       if (name.includes('.')) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -227,14 +227,38 @@ export const resolveLoaders = (input: Loader.LoaderModule[] = []): Loader.Loader
   }, [])
 );
 
+const isMergeable = (value: any): boolean => !!value && typeof value === 'object' && !Array.isArray(value);
+
+// Loaders sharing a `(locale, key)` namespace — route-scoped chunks of one
+// namespace — all contribute to it instead of the last one settling winning.
+// Plain objects merge branch by branch; anything else is a leaf, and a leaf
+// collision has no merge to perform, so the later loader's value is kept.
+const mergeTranslations = (target: any, source: any, path: string): any => {
+  if (!isMergeable(target) || !isMergeable(source)) {
+    logger.warn(`Conflicting translations for '${path}'. Keeping the value of the last loader.`);
+
+    return source;
+  }
+
+  return Object.keys(source).reduce((acc, key) => ({
+    ...acc,
+    [key]: hasOwn(acc, key) ? mergeTranslations(read(acc, key), read(source, key), `${path}.${key}`) : read(source, key),
+  }), target);
+};
+
 export const serialize = (input: Array<Loader.LoaderModule & { data: any }>) => {
   return input.reduce((acc, { key, data, locale }) => {
     if (!data) return acc;
 
     // The locale is already sanitized — loaders are normalized before the fetch.
+    const namespaces = read(acc, locale);
+
     return ({
       ...acc,
-      [locale]: { ...read(acc, locale), [key]: data },
+      [locale]: {
+        ...namespaces,
+        [key]: hasOwn(namespaces, key) ? mergeTranslations(read(namespaces, key), data, `${key}`) : data,
+      },
     });
   }, {} as Translations.SerializedTranslations);
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -210,6 +210,23 @@ export const toDotNotation: DotNotation.T = (input, preserveArrays, parentKey) =
   return input;
 };
 
+// Loader properties are consumer code — an accessor may throw. Materialized
+// once at the config boundary, so a single unreadable loader costs only itself
+// instead of taking down every locale-keyed read downstream.
+export const resolveLoaders = (input: Loader.LoaderModule[] = []): Loader.LoaderModule[] => (
+  input.reduce<Loader.LoaderModule[]>((acc, descriptor) => {
+    try {
+      const { key, locale, loader, routes } = descriptor;
+
+      return [...acc, { key, locale, loader, routes }];
+    } catch (error) {
+      logError('Skipping a loader that cannot be read.', error);
+
+      return acc;
+    }
+  }, [])
+);
+
 export const serialize = (input: Array<Loader.LoaderModule & { data: any }>) => {
   return input.reduce((acc, { key, data, locale }) => {
     if (!data) return acc;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -229,21 +229,27 @@ export const resolveLoaders = (input: Loader.LoaderModule[] = []): Loader.Loader
 
 const isMergeable = (value: any): boolean => !!value && typeof value === 'object' && !Array.isArray(value);
 
-// Loaders sharing a `(locale, key)` namespace — route-scoped chunks of one
-// namespace — all contribute to it instead of the last one settling winning.
-// Plain objects merge branch by branch; anything else is a leaf, and a leaf
-// collision has no merge to perform, so the later loader's value is kept.
-const mergeTranslations = (target: any, source: any, path: string): any => {
+// Data reaching a namespace that already holds some — route-scoped chunks of
+// one namespace, a later load, a second `addTranslations` — contributes to it
+// instead of replacing it. Plain objects merge branch by branch; anything else
+// is a leaf, and a leaf collision has no merge to perform, so the incoming
+// value is kept. Only callers for which a collision means an authoring mistake
+// pass `onConflict`.
+export const mergeTranslations = (target: any, source: any, path: string, onConflict?: (path: string) => void): any => {
   if (!isMergeable(target) || !isMergeable(source)) {
-    logger.warn(`Conflicting translations for '${path}'. Keeping the value of the last loader.`);
+    onConflict?.(path);
 
     return source;
   }
 
   return Object.keys(source).reduce((acc, key) => ({
     ...acc,
-    [key]: hasOwn(acc, key) ? mergeTranslations(read(acc, key), read(source, key), `${path}.${key}`) : read(source, key),
+    [key]: hasOwn(acc, key) ? mergeTranslations(read(acc, key), read(source, key), `${path}.${key}`, onConflict) : read(source, key),
   }), target);
+};
+
+const reportLoaderConflict = (path: string) => {
+  logger.warn(`Conflicting translations for '${path}'. Keeping the value of the last loader.`);
 };
 
 export const serialize = (input: Array<Loader.LoaderModule & { data: any }>) => {
@@ -257,7 +263,7 @@ export const serialize = (input: Array<Loader.LoaderModule & { data: any }>) => 
       ...acc,
       [locale]: {
         ...namespaces,
-        [key]: hasOwn(namespaces, key) ? mergeTranslations(read(namespaces, key), data, `${key}`) : data,
+        [key]: hasOwn(namespaces, key) ? mergeTranslations(read(namespaces, key), data, `${key}`, reportLoaderConflict) : data,
       },
     });
   }, {} as Translations.SerializedTranslations);

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -486,6 +486,39 @@ describe('i18n instance', () => {
     expect(instance.t('common.greeting')).toBe('Hello');
     expect(errorSpy).toHaveBeenCalled();
   });
+  it('merges loaders sharing a locale and key instead of keeping the last one', async () => {
+    const instance = new i18n({
+      parser: { parse: (text: any, _params: any, _locale: any, key: string) => (text === undefined ? key : text) },
+      log,
+      loaders: [
+        { key: 'common', locale: 'en', routes: ['/'], loader: async () => ({ menu: { home: 'Home' } }) },
+        { key: 'common', locale: 'en', loader: async () => ({ menu: { about: 'About' }, greeting: 'Hello' }) },
+      ],
+    });
+
+    await instance.loadTranslations('en', '/');
+
+    expect(instance.t('common.menu.home')).toBe('Home');
+    expect(instance.t('common.menu.about')).toBe('About');
+    expect(instance.t('common.greeting')).toBe('Hello');
+    expect(instance.rawTranslations['en']['common']).toEqual({ menu: { home: 'Home', about: 'About' }, greeting: 'Hello' });
+  });
+  it('keeps the last loader value on a leaf conflict and reports it', async () => {
+    const warnSpy = vi.fn();
+    const instance = new i18n({
+      parser: { parse: (text: any, _params: any, _locale: any, key: string) => (text === undefined ? key : text) },
+      log: { level: 'warn', logger: { error: () => {}, warn: warnSpy, debug: () => {} } },
+      loaders: [
+        { key: 'common', locale: 'en', loader: async () => ({ home: { title: 'Title' } }) },
+        { key: 'common', locale: 'en', loader: async () => ({ home: 'Home' }) },
+      ],
+    });
+
+    await instance.loadTranslations('en', '/');
+
+    expect(instance.t('common.home')).toBe('Home');
+    expect(warnSpy).toHaveBeenCalledWith("[i18n]: Conflicting translations for 'common.home'. Keeping the value of the last loader.");
+  });
   it('a loader receives its sanitized locale and the triggering route', async () => {
     const received: unknown[] = [];
     const instance = new i18n({

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -577,6 +577,26 @@ describe('i18n instance', () => {
 
     expect(errorSpy).not.toHaveBeenCalled();
   });
+  it('drops a loader whose accessor throws and keeps the resolvable ones', async () => {
+    const errorSpy = vi.fn();
+    const boom = new Error('locale accessor');
+    const instance = new i18n({
+      parser,
+      log: { level: 'error', logger: { error: errorSpy, warn: () => {}, debug: () => {} } },
+      loaders: [
+        { key: 'broken', get locale(): string { throw boom; }, loader: async () => ({ greeting: 'Ahoj' }) },
+        { key: 'common', locale: 'en', loader: async () => ({ greeting: 'Hello' }) },
+      ],
+    });
+
+    // A public read returns the resolvable subset instead of propagating.
+    expect(instance.locales).toEqual(['en']);
+    expect(errorSpy).toHaveBeenCalledWith('[i18n]: Skipping a loader that cannot be read.', boom);
+
+    await instance.loadTranslations('en', '/');
+
+    expect(instance.translations['en']['common.greeting']).toBe('Hello');
+  });
   it('reports a loader key containing a `.` character but keeps the loader', async () => {
     const errorSpy = vi.fn();
     const instance = new i18n();

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -519,6 +519,30 @@ describe('i18n instance', () => {
     expect(instance.t('common.home')).toBe('Home');
     expect(warnSpy).toHaveBeenCalledWith("[i18n]: Conflicting translations for 'common.home'. Keeping the value of the last loader.");
   });
+  it('merges data added to a namespace that already holds some', async () => {
+    const warnSpy = vi.fn();
+    const instance = new i18n({
+      parser: { parse: (text: any, _params: any, _locale: any, key: string) => (text === undefined ? key : text) },
+      log: { level: 'warn', logger: { error: () => {}, warn: warnSpy, debug: () => {} } },
+      initLocale: 'en',
+      loaders: [
+        { key: 'common', locale: 'en', loader: async () => ({ menu: { home: 'Home' } }) },
+      ],
+    });
+
+    await instance.loadTranslations('en', '/');
+    instance.addTranslations({ en: { common: { menu: { about: 'About' } } } });
+
+    expect(instance.t('common.menu.home')).toBe('Home');
+    expect(instance.t('common.menu.about')).toBe('About');
+    expect(instance.rawTranslations['en']['common']).toEqual({ menu: { home: 'Home', about: 'About' } });
+    expect(instance.snapshot()).toEqual({ en: { common: { menu: { home: 'Home', about: 'About' } } } });
+
+    instance.addTranslations({ en: { common: { menu: { home: 'Domov' } } } });
+
+    expect(instance.t('common.menu.home')).toBe('Domov');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
   it('a loader receives its sanitized locale and the triggering route', async () => {
     const received: unknown[] = [];
     const instance = new i18n({


### PR DESCRIPTION
## What

Three defects around translations that arrive in more than one piece, one commit each:

1. Loader descriptors are materialized once at the config boundary. A loader whose `locale`, `key`, `loader` or `routes` accessor throws is reported through the logger and dropped; every other loader keeps working.
2. Loaders declaring the same `locale` and `key` now merge into one namespace instead of the last one replacing the rest.
3. Data added to a namespace that already holds some now merges into it in both instance tables, instead of `translations` merging per leaf while `rawTranslations` replaced the whole namespace.

## Why

**Unreadable descriptors.** Loader objects are consumer code, so a throwing property accessor propagated out of every locale-keyed read. `locales` — a public read — threw synchronously, which violates the fail-soft posture the rest of the public surface follows. `snapshot()` and the loader filtering used by a load had the same exposure, each reading the same descriptors again.

**Shared keys.** `serialize` wrote `[key]: data`, so two loaders sharing a namespace — typically route-scoped chunks of one namespace — silently overwrote each other and the surviving chunk depended on the order they were declared in.

**Diverging tables.** `#addTranslations` merged `#rawTranslations` with a shallow namespace-level spread, while `#translations` merged after `toDotNotation`, i.e. per leaf. A namespace supplied by two separate calls therefore diverged: `t()` resolved both chunks while `rawTranslations` kept only the last. Because `snapshot()` reads `#rawTranslations`, the dropped chunk was silently missing from the SSR payload handed to the client. Reachable through two `addTranslations()` calls on the same namespace, and through two concurrent loads on different routes — both pass the loader filter before either records its key.

Fixes sveltekit-i18n/lib#220
Fixes sveltekit-i18n/lib#155
Relates to sveltekit-i18n/lib#217
Relates to sveltekit-i18n/lib#214

## How

**`resolveLoaders`.** `configLoader` runs `config.loaders` through the new helper before storing the config, so `#config.loaders` holds plain objects. Guarding one boundary rather than each reader keeps a single owner for the report — `locales`, `snapshot()`/`#offRouteKeys` and `#filterLoaders` are unchanged and simply read data that can no longer throw. The config-time loader-key check runs over the same resolved list, so a throwing `key` accessor no longer aborts the config load either.

Trade-off: descriptor properties are captured when the config is applied, so a property implemented as a getter is not re-evaluated on later loads. The `loader` function itself stays lazy. Documented in `docs/README.md`.

**Same-key merge.** `serialize` folds a loader's data into an already-claimed `(locale, key)` namespace through a recursive merge. Plain objects merge branch by branch; anything else is a leaf, so a leaf collision — including an object meeting a string, the case lib#155 left open — has no merge to perform: the loader declared later in `loaders` wins and the collision is reported through the logger. The order is the declaration order of `loaders`, not the order the loaders settle in: `fetchTranslations` awaits `Promise.all` over the loader array, so the outcome does not depend on which fetch is slower.

**One merge for both tables.** That recursive merge is now the exported `mergeTranslations`, and `#addTranslations` folds each locale's payload into both `#rawTranslations` and `#translations` with it. The conflict report stays a `serialize`-only concern and is passed in as an optional `onConflict`: two loaders in one config claiming the same leaf is an authoring mistake worth a warning, while `addTranslations` re-supplying a leaf — after `invalidate()` and a refetch, for instance — is routine and must stay quiet.

## Testing

- `npm test` — 111 passed (111).
- `npm run lint` — clean.
- `npm run build` — succeeds.

All four regression tests were verified in both directions against the unfixed code:

- `drops a loader whose accessor throws and keeps the resolvable ones` — `instance.locales` throws the accessor's error before the fix; after it, it returns the resolvable subset, the skip is reported through the configured logger, and the healthy loader still loads its data.
- `merges loaders sharing a locale and key instead of keeping the last one` — before the fix `t('common.menu.home')` returns the key itself (the second loader replaced the namespace); after it both chunks resolve and `rawTranslations` holds the merged namespace.
- `keeps the last loader value on a leaf conflict and reports it` — asserts the documented conflict rule and its warning.
- `merges data added to a namespace that already holds some` — before the fix `rawTranslations['en']['common']` is `{ menu: { about: 'About' } }` instead of the merged namespace (`AssertionError: expected { menu: { about: 'About' } } to deeply equal { menu: { home: 'Home', …(1) } }`) and `snapshot()` loses the first chunk with it; after it both tables hold both chunks, a re-supplied leaf takes the incoming value, and no warning is emitted.

## Checklist

- [x] **Tests pass locally** (`npm test`)
- [x] **Linter passes** (`npm run lint`)
- [x] **Build succeeds** (`npm run build`)
- [x] **All commits are atomic** (each commit works independently)
- [x] **Commits have clear messages** (imperative mood, descriptive)
- [x] **Branch rebased on latest master** (`git rebase origin/master`)
- [ ] **CHANGELOG.md updated** (if this changes functionality) — the repository has no `CHANGELOG.md`
- [x] **Documentation updated** (if API or behavior changed)

## Additional Notes

- lib#217 stays open: this PR lands only its same-key bullet (which absorbs lib#155); the derived loading model landed earlier with lib#216, and per-loader load records remain 3.1 scope.
- Load-once bookkeeping is still keyed by `key`, not by loader identity. Two loaders sharing a key but scoped to different routes therefore still load only the first one, so splitting a namespace into `routes`-scoped chunks keeps only the chunk whose route triggered the first load. Merging itself no longer depends on it. That limitation is tracked as sveltekit-i18n/lib#233 for 3.1 and is documented in `docs/README.md`.
- Out of scope, worth a follow-up: a throwing accessor on the **config object itself** (e.g. `get loaders()`) still aborts `configLoader`. It is reported through the logger and does not become an unhandled rejection, but the config is not applied.
- The branch name is imposed by the automation harness and does not follow the `fix/` convention from `AGENTS.md` §7.


---
_Generated by [Claude Code](https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV)_
