### PR TITLE
feat(types): typegen slots — key schema, locale union, param specs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,11 @@ translation state, loading, caching, route matching, and preprocessing — but
   expiry nor `invalidate` ever removes displayed translations or starts a
   load by itself. Don't break load-once semantics.
 - **Parser is injected, never imported.** `translate()` calls
-  `config.parser.parse(value, params, locale, key)`.
+  `config.parser.parse(value, params, locale, key)`. `Parser.ExtractParams` is
+  the build-time half of that contract and deliberately not a member of
+  `Parser.T` — a message scanner on the runtime parser object could never be
+  shaken out of a browser bundle — so a parser ships it from its own subpath
+  and the core never calls it.
 - **`config.extensions` is a construction-time pipe.** The constructor returns
   the instance folded through the extensions left to right, so
   `new I18n(config)` evaluates to the last extension's output; `loadConfig()`
@@ -111,7 +115,28 @@ translation state, loading, caching, route matching, and preprocessing — but
   local `I18nCore` class (a construct signature folds the type through the
   tuple); the same exported name is also the instance TYPE. The raw class is
   deliberately not exported. Extensions run after the synchronous prefix of
-  the config load — they receive a configured instance.
+  the config load — they receive a configured instance. Piping ERASES the
+  instance's type parameters: an extended surface is typed by the extension,
+  so neither `config.schema` nor the locale union survives it.
+- **`config.schema` types `t`/`l`, at construction time and type-only.** It
+  narrows keys and payloads from the config that reaches the constructor; only
+  its TYPE is read, so the slot may hold an empty value
+  (`{} as TranslationSchema`), and a schema whose keys are not a closed set
+  degrades to plain `string` keys rather than rejecting every call. This package ships the
+  slot, not the generator that fills it — never document a CLI or a plugin as
+  if it shipped here.
+- **Locales ride a fourth class type parameter**
+  (`I18n<ParserParams, ParserOutput, TranslationSchema, LocaleUnion>`), not an
+  intersection. The loader locales, `initLocale`, `fallbackLocale` and
+  `translations` keys a config spells narrow the inputs (`setLocale`,
+  `loadTranslations`, `invalidate`, `l`, assigning `locale`) and the reads
+  (`locale`, `locales`) alike; the translation tables stay `string`-keyed. The
+  union stays OPEN (`L | (string & {})`) — a completion hint, never a
+  constraint, since a locale can arrive from a URL, a cookie or an
+  `Accept-Language` header — and that openness is what keeps a narrowed
+  instance assignable to and from a plain `I18n`. One dynamic source degrades
+  the whole union to `string`: a half-known set would complete some locales
+  while silently hiding the rest.
 - **Preprocessing.** `addTranslations` applies `preprocess` (`'full'` default |
   `'preserveArrays'` | `'none'` | custom fn) via `toDotNotation`.
   `rawTranslations` is pre-preprocess; `translations` is post-preprocess. Keep

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Core i18n functionality for SvelteKit with support for custom message parsers. T
 ✅ **Route-aware** – Automatic loading based on SvelteKit routes  
 ✅ **Component-scoped** – Multiple translation instances with custom definitions  
 ✅ **Extensible** – Pipe the instance through [extensions](#extensions) to reshape or augment its surface  
-✅ **TypeScript** – Full type support  
+✅ **TypeScript** – Locales inferred from your config, keys and payloads from a [`schema`](#schema)  
 ✅ **Zero dependencies** – Lightweight and fast
 
 ## Installation
@@ -64,7 +64,7 @@ npm install @sveltekit-i18n/parser-icu
 import { I18n } from '@sveltekit-i18n/base';
 import parser from '@sveltekit-i18n/parser-default';
 
-/** @type {import('@sveltekit-i18n/base').Config} */
+/** @type {import('@sveltekit-i18n/base').Config.T} */
 const config = {
   parser: parser({ /* parser options */ }),
   loaders: [
@@ -186,6 +186,8 @@ loaders: [
 ]
 ```
 
+Both `loaders` and a loader's `routes` accept readonly arrays, so a whole-config `as const` is fine.
+
 ### `translations`
 
 Synchronous translations loaded immediately:
@@ -236,6 +238,21 @@ preprocess: 'full' // 'full' | 'preserveArrays' | 'none' | custom function
 - `'preserveArrays'`: Flattens objects but preserves arrays
 - `'none'`: No preprocessing
 - Custom function: `(input) => transformedOutput`
+
+### `schema`
+
+A map of translation key to the payload its message expects (`never` for a message that takes none). Supplying it types `t`/`l` — keys autocomplete, an unknown key is a type error, and the payload argument is checked. Only its type is read, so the value can stay empty at runtime:
+
+```typescript
+type TranslationSchema = {
+  'common.greeting': { name: string };
+  'common.farewell': never;
+};
+
+const i18n = new I18n({ ...config, schema: {} as TranslationSchema });
+```
+
+Hand-write it for a small set of messages, or point the slot at a generated artifact. A schema whose keys are not a closed set is ignored, and keys stay plain strings. See [`schema`](./docs/README.md#schema) for the full rules.
 
 ### `cache`
 
@@ -350,6 +367,17 @@ const config: Config.T<Params> = {
   loaders: [/* ... */],
 };
 ```
+
+Two more things are inferred from the config itself. [`schema`](#schema) types the keys and payloads of `t`/`l`, and every locale the config names — loader locales, `initLocale`, `fallbackLocale` and the keys of `translations` — completes the locale arguments and reads (`setLocale`, `loadTranslations`, `invalidate`, `l`, `locale`, `locales`):
+
+```typescript
+const i18n = new I18n({ parser: parser(), initLocale: 'en', fallbackLocale: 'de' });
+
+i18n.setLocale('en'); // 'en' | 'de' autocomplete here
+i18n.setLocale('sv'); // still accepted — the union is a hint, not a constraint
+```
+
+The locales survive only when the config reaches the constructor as a literal — inline, as above, or a separate object with `as const`. An annotated or separately widened config, and any config with one dynamic locale source (`loaders: locales.map(...)`), leaves them plain `string`. See [TypeScript](./docs/README.md#typescript) for both.
 
 ## Related Packages
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,11 +54,15 @@ const config = {
 
 ### `loaders`
 
-**Type:** `Loader.LoaderModule[]` (optional)
+**Type:** `readonly Loader.LoaderModule[]` (optional)
 
 Array of loader configurations that define how and when translations should be loaded.
 
 #### Loader Properties
+
+Both `loaders` and a loader's `routes` are typed as **readonly** arrays, so a
+whole config frozen with `as const` — routed loaders included — is accepted (see
+[Locale completion](#locale-completion)).
 
 Each loader object can have:
 
@@ -238,7 +242,7 @@ one route:
 
 ##### `routes` (optional)
 
-**Type:** `Array<string | RegExp | { test: (route: string) => boolean }>`
+**Type:** `readonly (string | RegExp | { test: (route: string) => boolean })[]`
 
 Array of route patterns. Loader will only execute if current route matches one of these patterns.
 
@@ -717,10 +721,97 @@ value is what gets stored and reported by [`locale`](#locale) and
 call that throws — or returns nothing usable — falls back to the locale as
 authored and is reported through the [logger](#loglevel).
 
+Because normalization may map an arbitrary input onto a known locale, the locale
+union TypeScript completes on the instance stays open — see
+[Locale completion](#locale-completion).
+
 **Use Cases:**
 - **Default:** one spelling per locale, whatever the source
 - **`false`:** non-ISO locale identifiers, or spellings that have to round-trip
 - **Function:** a project-wide convention (e.g. always lowercase)
+
+---
+
+### `schema`
+
+**Type:** `{ [translationKey]: PayloadType }` (optional)
+
+A map of each translation key to the payload its message expects — the slot a
+generated schema artifact fills. Supplying it types [`t()`](#tkey-params) and
+[`l()`](#llocale-key-params): keys autocomplete, an unknown key is a type error,
+and the payload argument is checked against the key's entry.
+
+**Only the type is read.** Nothing reads this value at runtime, so the artifact
+may be empty as long as it is typed:
+
+```typescript
+type TranslationSchema = {
+  'common.greeting': { name: string };  // payload required
+  'common.about': never;                // message takes no parameters
+  'home.title': { title?: string };     // nothing required — payload optional
+};
+
+const i18n = new I18n({
+  ...config,
+  schema: {} as TranslationSchema,
+});
+```
+
+**Accepted calls:**
+
+```typescript
+i18n.t('common.greeting', { name: 'Alice' });
+i18n.t('common.about');
+i18n.t('home.title');
+```
+
+**Rejected calls:**
+
+```typescript
+i18n.t('common.headline');                  // unknown translation key
+i18n.t('common.greeting');                  // missing payload
+i18n.t('common.greeting', { name: 42 });    // wrong payload shape
+i18n.t('common.about', { title: 'About' }); // payload for a message that takes none
+```
+
+**Payload rules:**
+
+- `never`, `undefined`, `void` or `null` — the message takes no parameters, so
+  the payload argument is omitted, and passing one is a type error.
+- A payload with no **required** property (`{ name?: string }`), or one the
+  schema itself marks optional (`{ value: string } | undefined`) — the argument
+  may be omitted.
+- `any` — the payload slot stays unchecked. That is not the same as "no
+  payload": anything passes, nothing is demanded.
+- A **union of keys** (`t(condition ? 'a' : 'b', …)`) takes the
+  **intersection** of their payloads — one call has to satisfy every key it
+  might be.
+
+The payload occupies slot 0 of the parser's params, so a parser's **trailing**
+slots survive: an ICU `formats` argument still type-checks after the payload.
+
+**⚠️ A schema whose keys are not a closed set is ignored.** An open index
+signature (`Record<string, …>`), or a schema with no keys at all, would reject
+every key or demand a payload for keys it knows nothing about — so keys stay
+plain strings instead and calls are typed as if no schema were supplied:
+
+```typescript
+new I18n({ ...config, schema: {} });
+new I18n({ ...config, schema: {} as Record<string, { value: string }> });
+```
+
+**⚠️ Construction time only.** The type is read off the config the constructor
+receives: a later [`loadConfig()`](#loadconfigconfig) cannot retype an existing
+instance, and [`extensions`](#extensions) erase the instance's type parameters
+altogether — an extended surface is typed by the extension, not by the schema.
+
+No generator ships in this package: the schema is a type you hand-write for a
+small project, or a generated artifact for a large one (see
+[Message parameter extraction](#message-parameter-extraction) for the
+build-time contract a generator reads messages through). The types the slot is
+resolved through are exported from the package root as the `Schema` namespace —
+`Schema.FromConfig`, `Schema.Key`, `Schema.Params` and `Schema.Payload` — for
+generators and wrapper packages; application code only supplies `schema`.
 
 ---
 
@@ -1006,7 +1097,9 @@ binding then stays in sync with the instance:
 **Type:** `(key: string, ...params: ParserParams) => ParserOutput`
 
 `ParserOutput` is inferred from the configured parser's `parse` return type and
-defaults to `string` (see [TypeScript](#typescript)).
+defaults to `string` (see [TypeScript](#typescript)). That is the un-narrowed
+signature: a [`schema`](#schema) narrows `key` to its keys and `params` to the
+payload that key declares.
 
 Translates `key` for the active locale.
 
@@ -1029,7 +1122,9 @@ updates when either changes. Outside templates it is an ordinary function call.
 **Type:** `(locale: string, key: string, ...params: ParserParams) => ParserOutput`
 
 Like `t`, for an explicit locale — useful for rendering a language switcher in
-each language's own name. The locale is normalized before the lookup
+each language's own name. A [`schema`](#schema) narrows `key` and `params` just
+as it does on `t`, and the locales the config names complete `locale` (see
+[Locale completion](#locale-completion)). The locale is normalized before the lookup
 ([`sanitizeLocales`](#sanitizelocales)), so by default `l('EN', ...)` and
 `l('en', ...)` read the same table.
 
@@ -1168,7 +1263,7 @@ requested locale, if one is known.
 
 ### `loadConfig(config)`
 
-**Type:** `(config: Config) => Promise<void>`
+**Type:** `(config: Config.T) => Promise<void>`
 
 (Re)configures the instance — same as passing the config to the constructor.
 Safe to call fire-and-forget: a failure is reported through the logger and the
@@ -1179,7 +1274,7 @@ the rejection.
 
 ### `configLoader(config)`
 
-**Type:** `(config: Config) => Promise<void>`
+**Type:** `(config: Config.T) => Promise<void>`
 
 The overridable seam a config is applied through. `loadConfig()` delegates to
 it, and the constructor goes through `loadConfig()`, so a wrapper package that
@@ -1342,7 +1437,7 @@ with [`snapshot()`](#snapshot).
 // src/lib/translations/index.js
 import parser from '@sveltekit-i18n/parser-default';
 
-/** @type {import('@sveltekit-i18n/base').Config} */
+/** @type {import('@sveltekit-i18n/base').Config.T} */
 export const config = {
   parser: parser(),
   loaders: [/* ... */],
@@ -1537,7 +1632,8 @@ The library provides:
 - ✅ Complete type definitions for configuration
 - ✅ Typed methods and reactive properties (`t`/`l` output inferred from the parser)
 - ✅ Generic types for custom parser integration
-- ❌ Automatic translation key inference (planned for the type generator)
+- ✅ Typed translation keys and payloads, from a [`schema`](#schema) you supply
+- ❌ Generating that schema from your translation files — the slot ships, not the generator
 
 ### Parser params and output inference
 
@@ -1570,6 +1666,156 @@ missing, the key itself when no parser is configured yet (see
 output, so a component consuming a rich output should tolerate it — either by
 setting a `fallbackValue` of the right shape, or by guarding the render.
 
+### Locale completion
+
+`new I18n(config)` also reads the locales the config **names** and completes
+them on the instance. Every config slot carrying one feeds the same union: each
+loader's `locale`, [`initLocale`](#initlocale),
+[`fallbackLocale`](#fallbacklocale) and the keys of
+[`translations`](#translations).
+
+```typescript
+const i18n = new I18n({
+  parser: parser(),
+  initLocale: 'en',
+  fallbackLocale: 'de',
+  translations: { cs: { greeting: 'Ahoj' } },
+  loaders: [{ locale: 'sk', key: 'common', loader: async () => ({}) }],
+});
+
+i18n.locale;  // 'en' | 'de' | 'cs' | 'sk' | (string & {}) | undefined
+```
+
+The union narrows **inputs** — `setLocale()`, `loadTranslations()`,
+`invalidate()`, the first argument of `l()`, and assignment to
+[`locale`](#locale) — and the **reads** [`locale`](#locale) and
+[`locales`](#locales). The [translation tables](#translations--rawtranslations)
+are not narrowed: they stay plain `string`-keyed records.
+
+**The union is open** — `Config.LocaleInput<L>` is `L | (string & {})`, so it
+drives completion without closing the input. A locale can arrive from a URL, a
+cookie or an `Accept-Language` header, and
+[`sanitizeLocales`](#sanitizelocales) may map an arbitrary input onto a known
+one. With the default normalization, an unlisted spelling compiles and lands on
+the locale it normalizes to:
+
+```typescript
+await i18n.setLocale('EN');
+
+i18n.locale;  // → 'en'
+```
+
+Staying open also keeps the narrowed instance assignable in both directions, so
+narrowing never makes the instance type invariant:
+
+```typescript
+const plain: I18n = i18n;
+const narrowed: I18n<any, string, never, 'en' | 'de'> = plain;
+```
+
+**The literals survive** when the config reaches the constructor as a literal
+type:
+
+```typescript
+new I18n({ parser: parser(), initLocale: 'en' });  // inline
+
+const frozen = { parser: parser(), initLocale: 'en' } as const;
+new I18n(frozen);                                  // `as const`
+
+const checked = { parser: parser(), initLocale: 'en' } as const satisfies Config.T<Params>;
+new I18n(checked);                                 // `as const satisfies`
+```
+
+**They are lost** — the union degrades to plain `string` — when the config is
+annotated (`const config: Config.T<Params> = { initLocale: 'en', … }`, since
+the annotation, not the literal, is the type the constructor sees), or when it
+is assigned separately without `as const` (`const config = { initLocale: 'en' }`
+widens `initLocale` to `string`).
+
+**⚠️ One dynamic source degrades the whole union.** A config that builds its
+loaders from a runtime array yields `string` even where it also names a
+literal:
+
+```typescript
+const locales: string[] = ['cs', 'sk'];
+
+const config = {
+  parser: parser(),
+  initLocale: 'en',
+  loaders: locales.map((locale) => ({ locale, key: 'common', loader: async () => ({}) })),
+} as const;
+
+// Config.LocalesFromConfig<typeof config> is `string`, not `'en'`
+```
+
+A half-known set would complete `'en'` while silently **hiding** every locale
+the dynamic source names — worse than completing nothing at all.
+
+`Config.LocaleInput<L>` and `Config.LocalesFromConfig<C>` are both exported, for
+code that has to spell the union it works with.
+
+### Message parameter extraction
+
+A [`schema`](#schema) maps each key to a payload, and something has to derive
+that payload from the messages themselves. `Parser.ExtractParams` is the
+**build-time** half of the parser contract: given a translation value, it
+reports the parameters that message expects, and a schema generator turns those
+reports into the schema artifact. **The core never calls it** — nothing in this
+package extracts anything at runtime.
+
+It is deliberately **not** a member of `Parser.T`. A message scanner attached to
+the runtime parser object could never be shaken out of a browser bundle, so a
+parser ships it from its **own subpath** instead, as an `ExtractParamsFactory`
+taking the same options the runtime parser takes — options decide what a message
+means (a custom modifier, a disabled tag syntax), so a generator has to build
+the extractor the way the app builds its parser:
+
+```typescript
+import type { Parser } from '@sveltekit-i18n/base';
+
+// Your parser exposes this from its own subpath:
+declare const extractParamsFactory: Parser.ExtractParamsFactory<{ modifiers?: string[] }>;
+
+const extract: Parser.ExtractParams = extractParamsFactory({ modifiers: [] });
+
+// Whatever the parser's own message syntax is:
+const params: readonly Parser.ParamSpec[] = extract('Hello {name}!', { key: 'common.greeting' });
+```
+
+A value that is not a message the parser recognizes yields `[]` rather than
+throwing — translation leaves are arbitrary data. The second argument
+(`Parser.ExtractContext`, `{ key?, locale? }`) is diagnostic only; neither
+official parser needs it to extract.
+
+**`Parser.ParamSpec` fields:**
+
+- **`name`** (required) — the key the payload is read by, already unescaped. It
+  is not necessarily a valid identifier, so a generator has to quote it.
+- **`kind`** — `'unknown' | 'string' | 'number' | 'boolean' | 'date' |
+  'function'`, or an array of them when the message uses the parameter in
+  several ways and any of them is valid. `'unknown'` is the **top** of this
+  lattice, not a conflict marker: merging it with anything yields the other
+  kind. `'date'` covers date and time formatting and means `Date | number`.
+  `'function'` is a rich-text callback, the shape ICU tags require. `'boolean'`
+  is there for parsers that can prove it — neither official parser can, since
+  both compare stringified values.
+- **`values`** — values the message names explicitly. A **hint** for authoring
+  tools, never an exhaustive set: both official parsers fall back to a default
+  branch for anything unlisted, so it must not be used to close a union. It is
+  omitted where the listed values are not values at all (numeric thresholds,
+  plural categories) or mean the opposite (an inequality's operands).
+- **`optional`** — whether the message renders without the parameter; defaults
+  to `false`. A parameter only some selector branches use is optional:
+  over-approximating trades a missed error for never demanding a parameter the
+  caller's branch has no use for.
+- **`when`** — the selector branches the parameter lives under, outermost first
+  (`{ param, branch }[]`). It lets a generator emit a discriminated payload
+  instead of the flat `optional: true` approximation; a generator that does not
+  care can ignore it.
+
+No official parser ships an extractor yet — these types are the contract one
+will ship against.
+
 ### Extensions and the constructor's type
 
 `new I18n(config)` is typed through a construct signature that folds the
@@ -1596,14 +1842,17 @@ const withGreeting = (i18n: I18n) => Object.assign(i18n, {
 export const i18n = new I18n({ ...config, extensions: [withGreeting] });
 ```
 
-Without `extensions`, the expression is a plain `I18n<ParserParams,
-ParserOutput>` — the exported `I18n` name is both the constructor value and the
-instance type. Bare `I18n` stands for the `string`-output instance, so
-`const i: I18n = new I18n(config)` fits a string parser; a rich-output parser
-needs its arguments spelled out (`I18n<Params, HtmlOutput>`), or no annotation
-at all, letting the constructor's inference stand.
+Without `extensions`, the expression is a plain
+`I18n<ParserParams, ParserOutput, TranslationSchema, LocaleUnion>` — the
+exported `I18n` name is both the constructor value and the instance type. The
+trailing two parameters default to no schema and open locales, so bare `I18n`
+stands for the `string`-output, un-narrowed instance:
+`const i: I18n = new I18n(config)` fits a string parser, while a rich-output
+parser needs its arguments spelled out (`I18n<Params, HtmlOutput>`), or no annotation at all,
+letting the constructor's inference stand.
 
-For type-safe translation keys, see [Best Practices](https://github.com/sveltekit-i18n/lib/tree/master/docs/BEST_PRACTICES.md#typescript-patterns).
+For type-safe translation keys, supply a [`schema`](#schema); the wider
+TypeScript patterns live in [Best Practices](https://github.com/sveltekit-i18n/lib/tree/master/docs/BEST_PRACTICES.md#typescript-patterns).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1177,6 +1177,22 @@ the rejection.
 
 ---
 
+### `configLoader(config)`
+
+**Type:** `(config: Config) => Promise<void>`
+
+The overridable seam a config is applied through. `loadConfig()` delegates to
+it, and the constructor goes through `loadConfig()`, so a wrapper package that
+subclasses the instance can inject its own defaults and have them apply to
+`new I18n(config)` as well — `sveltekit-i18n` wires its default parser this
+way.
+
+Application code calls [`loadConfig()`](#loadconfigconfig) instead: the public
+entry adds the destroyed-instance guard and marks the rejection handled, and
+this method does neither.
+
+---
+
 ### `addTranslations(translations)`
 
 **Type:** `(translations: Record<string, any>) => void`

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -5,7 +5,7 @@ import type { Config, Extension, Loader, Parser, Schema, Translations } from './
 
 const defaultCache = Number.POSITIVE_INFINITY;
 
-class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, TranslationSchema = never> {
+class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, TranslationSchema = never, LocaleUnion extends string = string> {
   // -- reactive state ---------------------------------------------------------
 
   #config = $state<Config.T<ParserParams, ParserOutput> | undefined>(undefined);
@@ -59,11 +59,11 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
    * a fire-and-forget `setLocale()` — the value therefore updates once the
    * locale's translations resolved, not synchronously on assignment.
    */
-  get locale(): Config.Locale | undefined {
+  get locale(): Config.LocaleInput<LocaleUnion> | undefined {
     return this.#locale;
   }
 
-  set locale(value: Config.Locale | undefined) {
+  set locale(value: Config.LocaleInput<LocaleUnion> | undefined) {
     if (value) void this.setLocale(value);
   }
 
@@ -77,7 +77,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
 
   loading: boolean = $derived(this.#pending.size > 0);
 
-  locales: Config.Locale[] = $derived.by(() => {
+  locales: Config.LocaleInput<LocaleUnion>[] = $derived.by(() => {
     if (!this.#config) return [];
 
     const { loaders = [] } = this.#config;
@@ -115,7 +115,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
   };
 
   /** Like `t`, for an explicit locale. */
-  l: Translations.LocalTranslationFunction<ParserParams, ParserOutput, TranslationSchema> = (locale, key, ...params) => {
+  l: Translations.LocalTranslationFunction<ParserParams, ParserOutput, TranslationSchema, LocaleUnion> = (locale, key, ...params) => {
     const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams, ParserOutput>;
 
     const [sanitizedLocale = locale] = this.#sanitize(locale);
@@ -203,7 +203,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
 
   // -- loading ----------------------------------------------------------------
 
-  setLocale = (locale?: Config.Locale): Promise<void> => {
+  setLocale = (locale?: Config.LocaleInput<LocaleUnion>): Promise<void> => {
     if (!locale || this.#inert('setLocale')) return Promise.resolve();
 
     if (locale !== this.#requestedLocale) {
@@ -233,7 +233,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
     return Promise.resolve();
   };
 
-  loadTranslations = (locale: Config.Locale, route = this.#route ?? ''): Promise<void> => {
+  loadTranslations = (locale: Config.LocaleInput<LocaleUnion>, route = this.#route ?? ''): Promise<void> => {
     if (!locale || this.#inert('loadTranslations')) return Promise.resolve();
 
     this.#requestedLocale = locale;
@@ -249,7 +249,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
    * flight for an invalidated locale is severed: it settles, but its data is
    * discarded — it predates the invalidation.
    */
-  invalidate = (locale?: Config.Locale): void => {
+  invalidate = (locale?: Config.LocaleInput<LocaleUnion>): void => {
     if (this.#inert('invalidate')) return;
 
     if (locale !== undefined) {
@@ -627,15 +627,18 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
 /**
  * A class declaration cannot annotate its constructor's return type, so the
  * extension pipe's construction-time type lives on this construct signature
- * instead: parser params and output are inferred from `config.parser`, and
- * the returned surface is the instance type folded through the
- * `config.extensions` tuple (`const` keeps it a tuple without `as const` at
- * the call site).
+ * instead: parser params and output are inferred from `config.parser`, locales
+ * are narrowed to the ones the config names, and the returned surface is the
+ * instance type folded through the `config.extensions` tuple
+ * (`const` keeps it a tuple without `as const` at the call site).
  */
 interface I18nConstructor {
   new <const C extends Config.T<any, any> = Config.T<any, any>>(
     config?: C
-  ): Extension.Piped<I18nCore<Parser.FromConfig<C>, Parser.OutputFromConfig<C>, Schema.FromConfig<C>>, Extension.FromConfig<C>>;
+  ): Extension.Piped<
+    I18nCore<Parser.FromConfig<C>, Parser.OutputFromConfig<C>, Schema.FromConfig<C>, Config.LocalesFromConfig<C>>,
+    Extension.FromConfig<C>
+  >;
 }
 
 // The raw class is deliberately not exported — every consumer constructs
@@ -643,7 +646,7 @@ interface I18nConstructor {
 // meanings: the value is the facade, the type is the un-piped instance.
 const I18n = I18nCore as unknown as I18nConstructor;
 
-type I18n<ParserParams extends Parser.Params = any, ParserOutput = string, TranslationSchema = never> = I18nCore<ParserParams, ParserOutput, TranslationSchema>;
+type I18n<ParserParams extends Parser.Params = any, ParserOutput = string, TranslationSchema = never, LocaleUnion extends string = string> = I18nCore<ParserParams, ParserOutput, TranslationSchema, LocaleUnion>;
 
 export { I18n };
 export default I18n;

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -1,11 +1,11 @@
 import { fetchTranslations, hasOwn, mergeTranslations, read, resolveLoaders, sanitizerFactory, sanitizeTranslationLocales, testRoute, toDotNotation, translate } from './utils.js';
 import { logError, logger, loggerFactory, setLogger } from './logger.js';
 
-import type { Config, Extension, Loader, Parser, Translations } from './types.js';
+import type { Config, Extension, Loader, Parser, Schema, Translations } from './types.js';
 
 const defaultCache = Number.POSITIVE_INFINITY;
 
-class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> {
+class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, TranslationSchema = never> {
   // -- reactive state ---------------------------------------------------------
 
   #config = $state<Config.T<ParserParams, ParserOutput> | undefined>(undefined);
@@ -100,7 +100,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
    * tracked: the call reads the translation table and locale, so a component
    * using `{i18n.t('key')}` re-renders when either changes.
    */
-  t: Translations.TranslationFunction<ParserParams, ParserOutput> = (key, ...params) => {
+  t: Translations.TranslationFunction<ParserParams, ParserOutput, TranslationSchema> = (key, ...params) => {
     const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams, ParserOutput>;
 
     return translate<ParserParams, ParserOutput>({
@@ -115,7 +115,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
   };
 
   /** Like `t`, for an explicit locale. */
-  l: Translations.LocalTranslationFunction<ParserParams, ParserOutput> = (locale, key, ...params) => {
+  l: Translations.LocalTranslationFunction<ParserParams, ParserOutput, TranslationSchema> = (locale, key, ...params) => {
     const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams, ParserOutput>;
 
     const [sanitizedLocale = locale] = this.#sanitize(locale);
@@ -635,7 +635,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string> 
 interface I18nConstructor {
   new <const C extends Config.T<any, any> = Config.T<any, any>>(
     config?: C
-  ): Extension.Piped<I18nCore<Parser.FromConfig<C>, Parser.OutputFromConfig<C>>, Extension.FromConfig<C>>;
+  ): Extension.Piped<I18nCore<Parser.FromConfig<C>, Parser.OutputFromConfig<C>, Schema.FromConfig<C>>, Extension.FromConfig<C>>;
 }
 
 // The raw class is deliberately not exported — every consumer constructs
@@ -643,7 +643,7 @@ interface I18nConstructor {
 // meanings: the value is the facade, the type is the un-piped instance.
 const I18n = I18nCore as unknown as I18nConstructor;
 
-type I18n<ParserParams extends Parser.Params = any, ParserOutput = string> = I18nCore<ParserParams, ParserOutput>;
+type I18n<ParserParams extends Parser.Params = any, ParserOutput = string, TranslationSchema = never> = I18nCore<ParserParams, ParserOutput, TranslationSchema>;
 
 export { I18n };
 export default I18n;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { default, I18n } from './I18n.svelte.js';
 
-export type { Config, Extension, Loader, Logger, Parser, Translations } from './types.js';
+export type { Config, Extension, Loader, Logger, Parser, Schema, Translations } from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,11 +72,11 @@ export namespace Config {
      */
     initLocale?: InitLocale;
     /**
-     * If you set this property, translations are automatically loaded not for current `$locale` only, but for this locale as well. In case there is no translation for current `$locale`, fallback locale translation is used instead of translation key placeholder. This is also used as a fallback when unknown locale is set.
+     * If you set this property, translations are automatically loaded not for current `locale` only, but for this locale as well. In case there is no translation for current `locale`, fallback locale translation is used instead of translation key placeholder. This is also used as a fallback when unknown locale is set.
      */
     fallbackLocale?: FallbackLocale;
     /**
-     * By default, translation key is returned in case no translation is found for given translation key. For example, `$t('unknown.key')` will result in `'unknown.key'` output. You can set this output value using this config prop.
+     * By default, translation key is returned in case no translation is found for given translation key. For example, `t('unknown.key')` will result in `'unknown.key'` output. You can set this output value using this config prop.
      */
     fallbackValue?: FallbackValue;
     /**
@@ -198,7 +198,7 @@ export namespace Loader {
 
   export type LoaderModule = {
     /**
-     * Represents the translation namespace. This key is used as a translation prefix so it should be module-unique. You can access your translation later using `$t('key.yourTranslation')`. It shouldn't include `.` (dot) character.
+     * Represents the translation namespace. This key is used as a translation prefix so it should be module-unique. You can access your translation later using `t('key.yourTranslation')`. It shouldn't include `.` (dot) character.
      */
     key: Key;
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,36 @@ export namespace Logger {
 export namespace Config {
   export type Locale = Translations.Locales[number];
 
+  /**
+   * A locale as the public surface takes and reports it: the locales the config
+   * spells, plus any other string. The set is a completion hint, never a
+   * constraint — a locale can arrive from a URL, a cookie or an
+   * `Accept-Language` header, and a custom `sanitizeLocales` may map an
+   * arbitrary input onto a known one.
+   */
+  export type LocaleInput<L extends string = string> = L | (string & {});
+
+  /** A locale-valued config property; `never` unless it carries a literal. */
+  type LocaleProp<C, K extends string> = C extends { [P in K]: infer L extends string } ? L : never;
+
+  type LocaleSources<C> =
+    | (C extends { loaders: readonly { locale: infer L extends string }[] } ? L : never)
+    | (C extends { translations: infer T } ? keyof T & string : never)
+    | LocaleProp<C, 'initLocale'>
+    | LocaleProp<C, 'fallbackLocale'>;
+
+  type ResolveLocales<L> = L extends string ? L : never;
+
+  /**
+   * The locales a config type spells – loader locales, `initLocale`,
+   * `fallbackLocale` and the keys of `translations`. Plain `Locale` when it
+   * spells none, and plain `Locale` as soon as ONE source is dynamic: a
+   * half-known set would complete some locales while silently hiding the rest.
+   */
+  export type LocalesFromConfig<C> = [LocaleSources<C>] extends [never]
+    ? Locale
+    : ResolveLocales<LocaleSources<C>>;
+
   export type InitLocale = Locale | undefined;
 
   export type FallbackLocale = Locale | undefined;
@@ -57,7 +87,7 @@ export namespace Config {
     /**
      * You can use loaders to define your asyncronous translation load. All loaded data are stored so loader is triggered only once – in case there is no previous version of the translation. It can get triggered again once the `config.cache` window elapses, or after `invalidate()` is called.
      */
-    loaders?: Loader.LoaderModule[];
+    loaders?: readonly Loader.LoaderModule[];
     /**
      * Locale-indexed translations, which should be in place before loaders will trigger. It's useful for static pages and synchronous translations – for example locally defined language names which are the same for all of the language mutations.
      *
@@ -230,7 +260,7 @@ export namespace Loader {
     /**
     * Define routes this loader should be triggered for. You can use Regular expressions or any object with a `test` method too. For example `[/\/.ome/]` will be triggered for `/home` and `/rome` route as well (but still only once). Leave this `undefined` in case you want to load this module with any route (useful for common translations).
     */
-    routes?: Route[];
+    routes?: readonly Route[];
   };
 
   /**
@@ -439,7 +469,7 @@ export namespace Translations {
 
   export type TranslationFunction<P extends Parser.Params = Parser.Params, O = string, S = never> = <K extends Schema.Key<S>>(key: K, ...restParams: Schema.Params<S, K, P>) => O;
 
-  export type LocalTranslationFunction<P extends Parser.Params = Parser.Params, O = string, S = never> = <K extends Schema.Key<S>>(locale: Config.Locale, key: K, ...restParams: Schema.Params<S, K, P>) => O;
+  export type LocalTranslationFunction<P extends Parser.Params = Parser.Params, O = string, S = never, L extends string = string> = <K extends Schema.Key<S>>(locale: Config.LocaleInput<L>, key: K, ...restParams: Schema.Params<S, K, P>) => O;
 
   export type Input<V = any> = { [K in any]: Input<V> | V };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -291,6 +291,81 @@ export namespace Parser {
   export type OutputFromConfig<C> = C extends { parser: T<any, infer O> }
     ? ([unknown] extends [O] ? string : O)
     : string;
+
+  /**
+   * What a message parameter accepts, as far as a message can say.
+   *
+   * `'unknown'` is the top of this lattice, not a conflict marker: merging it
+   * with anything yields the other kind. `'date'` covers both date and time
+   * formatting and means `Date | number`. `'function'` is a rich-text callback,
+   * the shape ICU tags require. `'boolean'` is here for parsers that can prove
+   * it – neither official parser can, since both compare stringified values.
+   */
+  export type ParamKind = 'unknown' | 'string' | 'number' | 'boolean' | 'date' | 'function';
+
+  /**
+   * One parameter a message expects. Produced by a parser's build-time
+   * extractor and consumed by a schema generator, never by the core.
+   */
+  export type ParamSpec = {
+    /**
+     * Name the payload is keyed by, already unescaped. It is not necessarily a
+     * valid identifier, so a generator has to quote it.
+     */
+    name: string;
+    /**
+     * What the parameter accepts; defaults to `'unknown'`. Several kinds mean
+     * the message uses the parameter in several ways and any of them is valid.
+     */
+    kind?: ParamKind | readonly ParamKind[];
+    /**
+     * Values the message names explicitly – a hint for authoring tools, never
+     * an exhaustive set. Both official parsers fall back to a default branch
+     * for anything unlisted, so this must not be used to close a union. Omit it
+     * where the listed values are not values at all (numeric thresholds, plural
+     * categories) or mean the opposite (an inequality's operands).
+     */
+    values?: readonly string[];
+    /**
+     * Whether the message renders without it; defaults to `false`. A parameter
+     * that only some selector branches use is optional – over-approximating
+     * here trades a missed error for never demanding a parameter the caller's
+     * branch has no use for.
+     */
+    optional?: boolean;
+    /**
+     * Selector branches this parameter lives under, outermost first. Lets a
+     * generator emit a discriminated payload instead of the flat
+     * `optional: true` approximation; a generator that doesn't care can ignore it.
+     */
+    when?: readonly { param: string; branch: string }[];
+  };
+
+  /** Diagnostic context for an extractor. Neither official parser needs it to extract. */
+  export type ExtractContext = {
+    key?: Key;
+    locale?: Locale;
+  };
+
+  /**
+   * Reports the parameters a message expects. This is the BUILD-TIME half of
+   * the parser contract and is deliberately not a member of `T`: a message
+   * scanner attached to the runtime parser object could never be shaken out of
+   * a browser bundle. A parser ships it from its own subpath instead, and the
+   * core never calls it.
+   *
+   * Values that are not messages the parser recognizes yield no parameters
+   * rather than throwing – translation leaves are arbitrary data.
+   */
+  export type ExtractParams = (message: Value, context?: ExtractContext) => readonly ParamSpec[];
+
+  /**
+   * Builds an `ExtractParams` from the same options the runtime parser takes.
+   * Options decide what a message means – a custom modifier or a disabled tag
+   * syntax changes which parameters exist – so a generator has to construct the
+   * extractor the way the app constructs its parser.
+   */
+  export type ExtractParamsFactory<O = unknown> = (options?: O) => ExtractParams;
 }
 
 export namespace Schema {

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export namespace Config {
 
   export type SanitizeLocales = boolean | ((locale: Locale) => Locale);
 
-  export type T<P extends Parser.Params = Parser.Params, O = Parser.Output> = {
+  export type T<P extends Parser.Params = Parser.Params, O = Parser.Output, S = any> = {
     /**
      * You can use loaders to define your asyncronous translation load. All loaded data are stored so loader is triggered only once – in case there is no previous version of the translation. It can get triggered again once the `config.cache` window elapses, or after `invalidate()` is called.
      */
@@ -112,6 +112,24 @@ export namespace Config {
      * This property defines translation syntax you want to use.
      */
     parser: Parser.T<P, O>;
+    /**
+     * A key schema — a map of translation key to the payload its message
+     * expects (`never` for a message without parameters). Supplying it types
+     * `t`/`l`: keys autocomplete and a wrong payload is a type error. Only its
+     * TYPE is read, so a generated artifact may export a value that is empty
+     * at runtime — as long as that value is TYPED, e.g.
+     * `export const schema = {} as TranslationSchema`. A schema whose keys are not a
+     * closed set (an open index signature, or no keys at all) is ignored and
+     * keys stay plain strings. Read at construction time only: a later
+     * `loadConfig()` cannot retype the instance, and `config.extensions`
+     * erases the instance's type parameters entirely.
+     *
+     * @example
+     * import { schema } from './generated/i18n-schema.js';
+     *
+     * const i18n = new I18n({ ...config, schema });
+     */
+    schema?: S;
     /**
      * Time in milliseconds the loaded translations stay fresh for. Once a locale's translations are older, the next load trigger runs its loaders again. By default, loaded translations never expire – call `invalidate()` (or set a finite `cache`) when your translation source can change at runtime, e.g. a CMS.
      *
@@ -275,14 +293,78 @@ export namespace Parser {
     : string;
 }
 
+export namespace Schema {
+  /**
+   * A schema types calls only when its keys form a specific, closed set. An
+   * untyped value, an empty object or an open index signature would otherwise
+   * reject every key or demand a payload for keys it knows nothing about, so
+   * they degrade to no schema at all.
+   */
+  type HasClosedKeys<S> = [keyof S & string] extends [never]
+    ? false
+    : string extends keyof S ? false : true;
+
+  /** The key schema carried by a config; `never` when there is none to use. */
+  export type FromConfig<C> = C extends { schema?: infer S extends object }
+    ? (HasClosedKeys<S> extends true ? S : never)
+    : never;
+
+  /** The keys a schema allows; any string when there is no schema. */
+  export type Key<S> = [S] extends [never] ? string : keyof S & string;
+
+  type IsAny<T> = 0 extends 1 & T ? true : false;
+
+  /**
+   * What satisfies every member of a union — see `Params`. An empty union stays
+   * `never`: no member means no payload, not an unconstrained one.
+   */
+  type UnionToIntersection<U> = [U] extends [never] ? never : (U extends unknown ? (x: U) => void : never) extends (x: infer I) => void ? I : never;
+
+  /**
+   * The parser's own params minus the payload slot the schema takes over. A
+   * params tuple that is unknown or open-ended contributes no trailing slots –
+   * keeping its rest open would let any number of junk arguments through.
+   */
+  type Trailing<P extends Parser.Params> = number extends P['length']
+    ? []
+    : P extends readonly [unknown?, ...infer R] ? R : [];
+
+  /**
+   * The payload argument, spliced into slot 0 of the parser's params so the
+   * parser's trailing slots (ICU `formats`, for instance) survive. A payload
+   * that carries no value marks a message without parameters; one with no
+   * REQUIRED property, or one the schema marks `Optional`, may be omitted.
+   * A schema value of `any` keeps the slot unchecked rather than forbidding it.
+   */
+  export type Payload<P extends Parser.Params, V, Optional extends boolean = false> = IsAny<V> extends true
+    ? [payload?: any, ...Trailing<P>]
+    : [V] extends [void | null]
+      ? [payload?: undefined, ...Trailing<P>]
+      // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+      : true extends Optional | ({} extends V ? true : never)
+        ? [payload?: V, ...Trailing<P>]
+        : [payload: V, ...Trailing<P>];
+
+  /**
+   * Rest params for `key` — the parser's own params when there is no schema.
+   * A union of keys takes the INTERSECTION of their payloads, since one call
+   * has to satisfy every key it might be.
+   */
+  export type Params<S, K extends string, P extends Parser.Params> = [S] extends [never]
+    ? P
+    : [K] extends [keyof S]
+      ? Payload<P, UnionToIntersection<Exclude<S[K & keyof S], undefined>>, undefined extends S[K & keyof S] ? true : false>
+      : P;
+}
+
 export namespace Translations {
   export type Locales<T = string> = T[];
 
   export type SerializedTranslations = LocaleIndexed<DotNotation.Input>;
 
-  export type TranslationFunction<P extends Parser.Params = Parser.Params, O = string> = (key: string, ...restParams: P) => O;
+  export type TranslationFunction<P extends Parser.Params = Parser.Params, O = string, S = never> = <K extends Schema.Key<S>>(key: K, ...restParams: Schema.Params<S, K, P>) => O;
 
-  export type LocalTranslationFunction<P extends Parser.Params = Parser.Params, O = string> = (locale: Config.Locale, key: string, ...restParams: P) => O;
+  export type LocalTranslationFunction<P extends Parser.Params = Parser.Params, O = string, S = never> = <K extends Schema.Key<S>>(locale: Config.Locale, key: K, ...restParams: Schema.Params<S, K, P>) => O;
 
   export type Input<V = any> = { [K in any]: Input<V> | V };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,7 +23,7 @@ export const translate = <P extends Parser.Params = Parser.Params, O = Parser.Ou
 }: {
   parser: Parser.T<P, O>;
   key: string;
-  params: P;
+  params: Parser.Params;
   translations: Translations.SerializedTranslations;
   locale: Translations.Locales[number] | undefined;
   fallbackLocale?: Config.FallbackLocale;
@@ -66,7 +66,9 @@ export const translate = <P extends Parser.Params = Parser.Params, O = Parser.Ou
     return text;
   }
 
-  return parser.parse(text, params, locale, key);
+  // A key schema narrows the rest params to one key's payload — still a `P`,
+  // but no longer provably so once the tuple has been rebuilt.
+  return parser.parse(text, params as P, locale, key);
 };
 
 // `Intl.Collator.supportedLocalesOf` is comparatively expensive and locales

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,7 +215,7 @@ export const toDotNotation: DotNotation.T = (input, preserveArrays, parentKey) =
 // Loader properties are consumer code — an accessor may throw. Materialized
 // once at the config boundary, so a single unreadable loader costs only itself
 // instead of taking down every locale-keyed read downstream.
-export const resolveLoaders = (input: Loader.LoaderModule[] = []): Loader.LoaderModule[] => (
+export const resolveLoaders = (input: readonly Loader.LoaderModule[] = []): Loader.LoaderModule[] => (
   input.reduce<Loader.LoaderModule[]>((acc, descriptor) => {
     try {
       const { key, locale, loader, routes } = descriptor;

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -905,6 +905,25 @@ describe('i18n extensions', () => {
     expect(calls).not.toHaveBeenCalled();
     expect(instance.t('common.key')).toBe('common.key');
   });
+  it('a configured extension erases the constructed type parameters', () => {
+    // `Config.T['extensions']` types every element `(input: any) => any`, so an
+    // extension that annotates neither side collapses the construction: the
+    // pipe reports what the extension's TYPE says, and that type says `any`.
+    const erased = new i18n({ parser, log, initLocale: 'en', fallbackLocale: 'de', extensions: [(input) => input] });
+
+    expectTypeOf(erased).toBeAny();
+
+    // An extension annotated with the bare instance type hands the bare
+    // instance back: the locale union the config spelled - and any schema - is
+    // gone.
+    const widened = new i18n({ parser, log, initLocale: 'en', fallbackLocale: 'de', extensions: [(input: I18n) => input] });
+
+    expectTypeOf(widened).toEqualTypeOf<I18n>();
+    expectTypeOf(widened.locale).toEqualTypeOf<Config.LocaleInput<string> | undefined>();
+    expectTypeOf(widened.locale).not.toEqualTypeOf<'en' | 'de' | (string & {}) | undefined>();
+
+    expect(widened).toBeInstanceOf(i18n);
+  });
 });
 
 describe('i18n loading concurrency', () => {

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -1680,6 +1680,94 @@ describe('type inference', () => {
     expect(extract(42)).toEqual([]);
     expect([detailed, nameless]).toHaveLength(2);
   });
+
+  it('reads the locales a config names off every slot that carries one', () => {
+    const config = {
+      parser,
+      log,
+      initLocale: 'en',
+      fallbackLocale: 'de',
+      translations: { cs: { greeting: 'Ahoj' } },
+      loaders: [{ locale: 'sk', key: 'common', routes: ['/about'], loader: async () => ({}) }],
+    } as const;
+
+    // Every config slot that names a locale feeds the same union — the one the
+    // instance takes and reports. A loader's `routes` is frozen by the same
+    // `as const` and must not reject the literal config.
+    expectTypeOf<Config.LocalesFromConfig<typeof config>>().toEqualTypeOf<'en' | 'de' | 'cs' | 'sk'>();
+
+    // The union stays open: a custom `sanitizeLocales` may map an arbitrary
+    // input onto a known locale, so an unlisted one is still accepted.
+    expectTypeOf<Config.LocaleInput<'en' | 'de'>>().toEqualTypeOf<'en' | 'de' | (string & {})>();
+    expectTypeOf<Config.LocaleInput>().toEqualTypeOf<string>();
+
+    expect(new i18n(config)).toBeInstanceOf(i18n);
+  });
+
+  it('leaves locale inputs open when the config names no literal locale', () => {
+    // An annotated config erases the literals, and so does a widened one.
+    const annotated: Config.T = { parser, log, initLocale: 'en' };
+    const widened = { parser, log, initLocale: 'en' };
+
+    expectTypeOf<Config.LocalesFromConfig<typeof annotated>>().toEqualTypeOf<string>();
+    expectTypeOf<Config.LocalesFromConfig<typeof widened>>().toEqualTypeOf<string>();
+
+    const instance = new i18n(annotated);
+
+    void instance.setLocale('anything');
+    void instance.l('anything', 'key');
+
+    expect(instance).toBeInstanceOf(i18n);
+    expect(new i18n(widened)).toBeInstanceOf(i18n);
+  });
+
+  it('degrades the locale union to plain strings when one source is dynamic', () => {
+    const dynamicLocales: string[] = ['cs', 'sk'];
+
+    const config = {
+      parser,
+      log,
+      initLocale: 'en',
+      loaders: dynamicLocales.map((locale) => ({ locale, key: 'common', loader: async () => ({}) })),
+    } as const;
+
+    // A half-known union would complete `'en'` while silently hiding every
+    // locale the dynamic source names.
+    expectTypeOf<Config.LocalesFromConfig<typeof config>>().toEqualTypeOf<string>();
+
+    expect(new i18n(config)).toBeInstanceOf(i18n);
+  });
+
+  it('narrows locale inputs and reads while keeping the instance assignable', () => {
+    const instance = new i18n({ parser, log, initLocale: 'en', fallbackLocale: 'de' });
+
+    type Narrowed = 'en' | 'de' | (string & {});
+
+    expectTypeOf<Parameters<typeof instance.setLocale>[0]>().toEqualTypeOf<Narrowed | undefined>();
+    expectTypeOf<Parameters<typeof instance.loadTranslations>[0]>().toEqualTypeOf<Narrowed>();
+    expectTypeOf<Parameters<typeof instance.invalidate>[0]>().toEqualTypeOf<Narrowed | undefined>();
+    expectTypeOf<Parameters<typeof instance.l>[0]>().toEqualTypeOf<Narrowed>();
+
+    // Reads carry the same union: the locale the instance reports is the one
+    // it was asked for, sanitized.
+    expectTypeOf(instance.locale).toEqualTypeOf<Narrowed | undefined>();
+    expectTypeOf(instance.locales).toEqualTypeOf<Narrowed[]>();
+
+    // A locale outside the union still passes — narrowing drives completion,
+    // it does not close the input.
+    void instance.setLocale('sv');
+    void instance.loadTranslations('sv');
+    instance.invalidate('sv');
+    void instance.l('sv', 'key');
+    instance.locale = 'sv';
+
+    // The union stays open in both directions, so narrowing never makes the
+    // instance type invariant.
+    const untyped: I18n = instance;
+    const renarrowed: I18n<any, string, never, 'en' | 'de'> = untyped;
+
+    expect(renarrowed).toBeInstanceOf(i18n);
+  });
 });
 
 describe('utils', () => {

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -1651,6 +1651,35 @@ describe('type inference', () => {
 
     expect(instance).toBeInstanceOf(i18n);
   });
+
+  it('describes extracted params without pulling an extractor into the core', () => {
+    // `name` is the only thing a message always yields; everything else is a
+    // refinement a parser may or may not be able to prove.
+    const minimal: Parser.ParamSpec = { name: 'value' };
+    const detailed: Parser.ParamSpec = {
+      name: 'count',
+      kind: ['number', 'string'],
+      values: ['one', 'other'],
+      optional: true,
+      when: [{ param: 'gender', branch: 'female' }],
+    };
+
+    // An extractor is built from the same options the runtime parser takes, and
+    // reads a translation value – not a parser instance.
+    const factory: Parser.ExtractParamsFactory<{ modifiers?: string[] }> = () =>
+      (message, context) => (typeof message === 'string' && context?.key ? [minimal] : []);
+    const extract: Parser.ExtractParams = factory({ modifiers: [] });
+
+    // @ts-expect-error a spec without a name says nothing a generator can use
+    const nameless: Parser.ParamSpec = { kind: 'string' };
+
+    expectTypeOf(extract).parameters.toEqualTypeOf<[Parser.Value, (Parser.ExtractContext | undefined)?]>();
+    expectTypeOf(extract).returns.toEqualTypeOf<readonly Parser.ParamSpec[]>();
+
+    expect(extract('a message', { key: 'a.key', locale: 'en' })).toEqual([minimal]);
+    expect(extract(42)).toEqual([]);
+    expect([detailed, nameless]).toHaveLength(2);
+  });
 });
 
 describe('utils', () => {

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import i18n from '../../src/index.js';
-import type { I18n } from '../../src/index.js';
+import type { Config, I18n, Parser } from '../../src/index.js';
 import { logger, loggerFactory, setLogger } from '../../src/logger.js';
 import { read, sanitizeLocales, testRoute, toDotNotation, translate } from '../../src/utils.js';
 import * as publicUtils from '../../src/exports/utils.js';
@@ -1546,6 +1546,98 @@ describe('type inference', () => {
 
     expect(rich).toBeInstanceOf(i18n);
     expect(plain).toBeInstanceOf(i18n);
+  });
+
+  it('narrows `t`/`l` keys and params to a supplied key schema', async () => {
+    type TestSchema = {
+      'common.no_placeholder': never;
+      'common.void': undefined;
+      'common.placeholder': { value: string };
+      'common.optional': { value?: string };
+      'common.maybe': { value: string } | undefined;
+      'common.loose': any;
+    };
+
+    // Only the TYPE of the slot is read — the generator emits a bare object.
+    const schema = {} as TestSchema;
+    const instance = new i18n({ ...CONFIG, schema });
+
+    expectTypeOf(instance.t('common.placeholder', { value: 'a' })).toEqualTypeOf<string>();
+    expectTypeOf(instance.l('en', 'common.placeholder', { value: 'a' })).toEqualTypeOf<string>();
+
+    // A message without params takes no payload; an all-optional one may omit it.
+    instance.t('common.no_placeholder');
+    instance.t('common.void');
+    instance.t('common.optional');
+
+    // A payload the schema marks optional is omittable, not forbidden.
+    instance.t('common.maybe', { value: 'a' });
+    instance.t('common.maybe');
+
+    // An `any` slot stays unchecked rather than collapsing to "no payload".
+    instance.t('common.loose', { anything: true });
+    instance.t('common.loose');
+
+    // @ts-expect-error unknown translation key
+    instance.t('common.unknown');
+    // @ts-expect-error wrong payload shape
+    instance.t('common.placeholder', { value: 1 });
+    // @ts-expect-error missing payload
+    instance.t('common.placeholder');
+    // @ts-expect-error arguments past the payload the parser declares
+    instance.t('common.placeholder', { value: 'a' }, 'junk');
+    // @ts-expect-error wrong payload shape behind an optional union
+    instance.t('common.maybe', { value: 1 });
+    // @ts-expect-error payload passed to a message that takes none
+    instance.t('common.no_placeholder', { value: 'a' });
+    // @ts-expect-error payload passed to a message that takes none
+    instance.t('common.void', { value: 'a' });
+
+    // A key that is a union has to satisfy every key it might be.
+    const eitherKey: 'common.no_placeholder' | 'common.placeholder' = 'common.placeholder';
+
+    instance.t(eitherKey, { value: 'a' });
+    // @ts-expect-error missing payload behind a union of keys
+    instance.t(eitherKey);
+
+    // The slot is inert at runtime — the instance loads and translates as usual.
+    await instance.loadTranslations('EN', '/');
+    expect(instance.t('common.no_placeholder')).toBe('common.no_placeholder');
+  });
+
+  it('reads the key schema off an annotated config, and ignores an open one', () => {
+    type TestSchema = { 'common.placeholder': { value: string } };
+
+    // `Config.T` declares `schema` optional, so the annotated form has to match
+    // just as the inferred one does.
+    const config: Config.T<Parser.Params, string, TestSchema> = { ...CONFIG, schema: {} as TestSchema };
+    const annotated = new i18n(config);
+
+    annotated.t('common.placeholder', { value: 'a' });
+    // @ts-expect-error unknown translation key
+    annotated.t('common.unknown');
+
+    // A schema without a closed key set types nothing — keys stay plain strings
+    // rather than every call failing. The shape comes from an annotation, not
+    // an `as`: the slot accepts a bare object, so lint strips the assertion.
+    const openKeys: Record<string, { value: string }> = {};
+    const open = new i18n({ ...CONFIG, schema: openKeys });
+    const noKeys = new i18n({ ...CONFIG, schema: {} });
+
+    open.t('any.key', 'anything', 1);
+    noKeys.t('any.key', 'anything', 1);
+
+    expect(annotated).toBeInstanceOf(i18n);
+  });
+
+  it('leaves `t`/`l` untyped when no key schema is supplied', () => {
+    const instance = new i18n({ parser, log });
+
+    expectTypeOf(instance.t('any.key')).toEqualTypeOf<string>();
+    instance.t('any.key', 'anything', 1);
+    instance.l('en', 'any.key', 'anything', 1);
+
+    expect(instance).toBeInstanceOf(i18n);
   });
 
   it('falls back to a `string` output for an untyped parser', () => {


### PR DESCRIPTION
## What

Adds the type-level slots a generated typegen artifact plugs into, and documents them.

- **`config.schema`** — an optional, type-only key schema. Supplying it narrows `t`/`l`: keys autocomplete and a wrong payload is a type error. No schema (or a schema whose keys are not a closed set) keeps today's plain-`string` behaviour.
- **Locale inference** — the locales a config names (loader `locale`s, `initLocale`, `fallbackLocale`, `translations` keys) become a fourth class type parameter, completing every locale-facing input and read.
- **`ParamSpec` / `Parser.ExtractParams`** — the build-time contract a parser implements so a generator can scan messages and emit the payload types the schema carries.
- **Docs** — `docs/README.md`, `README.md` and `AGENTS.md` describe all three.

No runtime behaviour changes: the whole PR is types, tests and docs, apart from the generic threading in `I18n.svelte.ts`/`utils.ts`.

## Why

`t('key')` was `string`-keyed and `params` was the parser's raw param type, so nothing caught a typo'd key or a payload the message does not accept. The generator that fills these slots lives outside this package (lib#234); this PR ships the slots it needs, so the two can land independently.

Fixes sveltekit-i18n/lib#221
Fixes sveltekit-i18n/lib#65
Relates to sveltekit-i18n/lib#60
Relates to sveltekit-i18n/lib#188

## How

Five commits, each self-contained:

1. **`docs: drop v2 store syntax from JSDoc and document configLoader`** — clears the stale store-era wording out of the `types.ts` JSDoc the later commits build on, and documents `configLoader`.
2. **`feat(types): type t/l from an optional key schema`** — adds the `Schema` namespace (`HasClosedKeys`, `Key`, `Payload`, `Params`, `Trailing`) and a third class type parameter carrying the schema. `Schema.Params` maps a key to its payload tuple: an object payload is required, `never`/`undefined`/`void`/`null` mean the message takes none and passing one is an error. `HasClosedKeys` degrades an open or empty schema back to plain `string` keys rather than rejecting every call.
3. **`feat(types): describe extracted message params`** — adds `ParamSpec` and `Parser.ExtractParams`/`ExtractParamsFactory`. Deliberately *not* a member of `Parser.T`: a message scanner hanging off the runtime parser object could never be shaken out of a browser bundle, so a parser ships it from its own subpath and the core never calls it.
4. **`feat(types): narrow locales to the ones the config names`** — adds the fourth type parameter and `Config.LocalesFromConfig`. The union stays **open** (`L | (string & {})`) — a completion hint, not a constraint, since a locale can arrive from a URL, a cookie or an `Accept-Language` header. That openness is also what keeps a narrowed instance assignable to and from a plain `I18n`. One dynamic (non-literal) locale source degrades the whole union to `string`; a half-known set would complete some locales while silently hiding the rest.
5. **`docs: document the schema slot, locale completion and param specs`** — the reference sections plus the architecture rules in `AGENTS.md`.

Because a class cannot annotate its constructor's return type, the exported `I18n` stays a typed facade over the local `I18nCore`; the added parameters ride that facade. `config.extensions` erases the instance's type parameters, as it already did — documented in both `docs/README.md` and the `types.ts` JSDoc.

## Testing

`npm test` — **120 tests in 1 file, all passing** (up from 111 on master); `npm run typecheck` runs as part of it. `npm run lint` and `npm run build` clean. Each commit's tip verified independently green (111 / 114 / 115 / 119 / 120 tests).

Type-level assertions are compile-time: the new blocks in `tests/specs/index.spec.ts` use `@ts-expect-error` for every rejection (unknown key, missing payload, wrong payload shape, payload passed to a message that takes none, unknown locale is *not* rejected by design) so `typecheck` fails if the types stop rejecting — or start rejecting — what they should.

One real bug was found and fixed red → green while writing those assertions: `Schema.Params` mapped a `never` (and `undefined`) payload to `[payload?: unknown]`, so `t('common.no_placeholder', { value: 'a' })` compiled. Root cause is `UnionToIntersection<never>` inferring `unknown` rather than `never`; guarded with `[U] extends [never] ? never : …`. The two `@ts-expect-error` lines covering it were confirmed to report `TS2578: Unused '@ts-expect-error' directive` against the unfixed code.

Every load-bearing snippet in the new docs was compiled against `src/` in a scratch project (`tsc --noEmit`, exit 0), and the inferred locale union was checked with an `Exact<>` probe rather than plain assignability — `string & {}` collapses under bidirectional assignment, which would have made a naive check vacuous. All anchors in the three touched markdown files resolve.

## Checklist

- [x] **Tests pass locally** (`npm test`)
- [x] **Linter passes** (`npm run lint`)
- [x] **Build succeeds** (`npm run build`)
- [x] **All commits are atomic** (each commit works independently)
- [x] **Commits have clear messages** (imperative mood, descriptive)
- [x] **Branch rebased on latest master** (`git rebase origin/master`)
- [ ] **CHANGELOG.md updated** — n/a, this repo has no `CHANGELOG.md`
- [x] **Documentation updated**

## Additional Notes

Out of scope, tracked separately:

- **sveltekit-i18n/lib#234** — the generator itself: the bundler plugin that reads the translation files and emits the schema these slots consume.
- **sveltekit-i18n/lib#227** — the parsers' side of the extraction contract, i.e. the actual `extractParams` implementations.
- **sveltekit-i18n/lib#236** — a member-access surface (`t.ns.key({ ... })`) layered on top of these types.

`config.extensions` erasing the instance's type parameters is now pinned by a compile-time test (`a configured extension erases the constructed type parameters`) rather than only documented. Two faces of that erasure are locked in as-is:

- An extension that annotates neither side is captured as `(input: any) => any` — `Config.T['extensions']` supplies that contextual type — so `Extension.Piped` folds to `any`. The circularity is genuine: the contextual type would have to be the very instance type being inferred.
- An extension annotated with the bare `I18n` hands the bare instance back, so a spelled locale union (and any schema) is dropped. That is the pipe faithfully reporting what the extension declares.

Guarding the first with `[unknown] extends [O] ? Instance : O` (the convention `Parser.OutputFromConfig` already uses) was prototyped and measured: it recovers the narrowed instance for an `Extension.T`-typed export, but mis-asserts the instance shape for extensions that genuinely return `any`. That is a behaviour change to the public construction type and is left for a separate decision.