### PR TITLE
fix(types): repair schema payload folding and extension surface typing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,9 +115,15 @@ translation state, loading, caching, route matching, and preprocessing — but
   local `I18nCore` class (a construct signature folds the type through the
   tuple); the same exported name is also the instance TYPE. The raw class is
   deliberately not exported. Extensions run after the synchronous prefix of
-  the config load — they receive a configured instance. Piping ERASES the
-  instance's type parameters: an extended surface is typed by the extension,
-  so neither `config.schema` nor the locale union survives it.
+  the config load — they receive a configured instance. An extension typed by a
+  fixed return type ERASES the instance's type parameters: that surface is typed
+  by the extension, so neither `config.schema` nor the locale union survives it.
+  An extension whose output depends on its input declares that with an
+  `Extension.Operator` — an interface expressing `output` through
+  `this['input']`, applied by `Extension.Apply` and carried as a type-only brand
+  by `Extension.Generic`. A generic FUNCTION signature cannot carry that
+  dependency: reading one instantiates its type parameters at their constraints,
+  so the pipe would fold `unknown` and erase the surface outright.
 - **`config.schema` types `t`/`l`, at construction time and type-only.** It
   narrows keys and payloads from the config that reaches the constructor; only
   its TYPE is read, so the slot may hold an empty value

--- a/docs/README.md
+++ b/docs/README.md
@@ -809,8 +809,10 @@ new I18n({ ...config, schema: {} as Record<string, { value: string }> });
 
 **⚠️ Construction time only.** The type is read off the config the constructor
 receives: a later [`loadConfig()`](#loadconfigconfig) cannot retype an existing
-instance, and [`extensions`](#extensions) erase the instance's type parameters
-altogether — an extended surface is typed by the extension, not by the schema.
+instance, and an [`extension`](#extensions) typed by a fixed return type erases
+the instance's type parameters altogether — that surface is typed by the
+extension, not by the schema. An extension typed by an `Extension.Operator`
+keeps them (see [Extensions and the constructor's type](#extensions-and-the-constructors-type)).
 
 No generator ships in this package: the schema is a type you hand-write for a
 small project, or a generated artifact for a large one (see
@@ -946,7 +948,9 @@ const minimal = (i18n) => ({
   `instance`.
 - **Typed end to end.** The type of `new I18n(config)` folds through the
   `extensions` tuple, so the expression's type is the last extension's return
-  type (see [TypeScript](#typescript)).
+  type. An extension whose output shape depends on the surface it receives
+  declares that dependency with an `Extension.Operator` (see
+  [TypeScript](#typescript)).
 
 Official extensions live in the
 [extensions](https://github.com/sveltekit-i18n/extensions) repository.
@@ -1850,6 +1854,40 @@ const withGreeting = (i18n: I18n) => Object.assign(i18n, {
 // Typed as I18n & { greet: (name: string) => string }:
 export const i18n = new I18n({ ...config, extensions: [withGreeting] });
 ```
+
+**Keeping the surface an extension was handed.** The extension above spells its
+input as the bare `I18n`, so that is what the pipe folds on: the
+[`schema`](#schema) and the locale union the config narrowed are gone from the
+result. Making the function generic (`<I>(i18n: I) => I & { … }`) does not help
+— reading a generic signature instantiates its type parameters at their
+constraints, so the pipe would fold `unknown` and erase the surface entirely.
+
+Declare the dependency as an `Extension.Operator` instead. It is an interface
+with an `input` and an `output`, and the output is expressed through `this`:
+
+```typescript
+import { I18n, type Extension } from '@sveltekit-i18n/base';
+
+interface WithGreeting extends Extension.Operator {
+  readonly output: this['input'] & { greet: (name: string) => string };
+}
+
+const withGreeting: Extension.Generic<WithGreeting> = (i18n: I18n) => Object.assign(i18n, {
+  greet: (name: string) => i18n.t('common.greeting', { name }),
+});
+
+// Typed as the narrowed instance & { greet: … } — schema and locales intact:
+export const i18n = new I18n({ ...config, extensions: [withGreeting] });
+
+i18n.t('common.greeting', { name: 'World' }); // still key- and payload-checked
+```
+
+`Extension.Generic<O>` is `Extension.T` carrying `O` as a type-only brand, so
+the function itself is written as usual — the annotation is the only difference.
+The pipe applies each operator to the surface reaching it, so operators compose:
+a stores adapter layered over a greeting extension sees both. An extension
+without an operator keeps the old behavior and contributes its declared return
+type.
 
 Without `extensions`, the expression is a plain
 `I18n<ParserParams, ParserOutput, TranslationSchema, LocaleUnion>` — the

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -5,6 +5,8 @@ import type { Config, Extension, Loader, Parser, Schema, Translations } from './
 
 const defaultCache = Number.POSITIVE_INFINITY;
 
+type LoadedKeys = Translations.LocaleIndexed<Loader.Key[]>;
+
 class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, TranslationSchema = never, LocaleUnion extends string = string> {
   // -- reactive state ---------------------------------------------------------
 
@@ -32,7 +34,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
 
   // Null prototype: these tables are indexed by user-supplied locales, and a
   // plain object would resolve a '__proto__' assignment via the setter.
-  #loadedKeys: Loader.IndexedKeys = Object.create(null);
+  #loadedKeys: LoadedKeys = Object.create(null);
 
   /** When each locale first received data — drives the `cache` expiry. */
   #loadedAt: Translations.LocaleIndexed<number> = Object.create(null);
@@ -349,7 +351,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
   async #getTranslationProps(
     locale: Config.Locale,
     route: string,
-  ): Promise<[Translations.SerializedTranslations, Loader.IndexedKeys] | []> {
+  ): Promise<[Translations.SerializedTranslations, LoadedKeys] | []> {
     if (!this.#config || !locale) return [];
 
     const [sanitizedLocale] = this.#sanitize(locale);
@@ -363,7 +365,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
 
     const loadedKeys = Object.entries(rawTranslations).reduce(
       (acc, [translationLocale, data]) => ({ ...acc, [translationLocale]: Object.keys(data ?? {}) }),
-      {} as Loader.IndexedKeys,
+      {} as LoadedKeys,
     );
 
     const keys = filteredLoaders
@@ -372,7 +374,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
         // sibling `nav` loader as loaded.
         (loadedKey) => `${loadedKey}` === key || `${loadedKey}`.startsWith(`${key}.`),
       ))
-      .reduce<Loader.IndexedKeys>((acc, { key, locale: loaderLocale }) => ({
+      .reduce<LoadedKeys>((acc, { key, locale: loaderLocale }) => ({
         ...acc,
         [loaderLocale]: [...(read<Loader.Key[]>(acc, loaderLocale) || []), key],
       }), {});
@@ -385,7 +387,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
    * `keys` carries the exact loader keys of a load; without it (the public
    * `addTranslations` path) loaded keys derive from the data's top-level keys.
    */
-  #addTranslations(translations?: Translations.SerializedTranslations, keys?: Loader.IndexedKeys): void {
+  #addTranslations(translations?: Translations.SerializedTranslations, keys?: LoadedKeys): void {
     if (!translations) return;
 
     const { preprocess } = this.#config ?? {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,8 +269,6 @@ export namespace Loader {
 
   export type Route = string | RegExp | RouteMatcher;
 
-  export type IndexedKeys = Translations.LocaleIndexed<Key[]>;
-
   /** The load context every loader is called with. */
   export type Props = {
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -422,10 +422,21 @@ export namespace Schema {
   type IsAny<T> = 0 extends 1 & T ? true : false;
 
   /**
-   * What satisfies every member of a union — see `Params`. An empty union stays
-   * `never`: no member means no payload, not an unconstrained one.
+   * What satisfies every key in `K` — see `Params`. The fold runs over the
+   * KEYS, so each key's own payload reaches the intersection whole; folding
+   * over the payloads instead would collapse a single key's discriminated
+   * union to `never` and type the message as parameterless. A key that carries
+   * no payload contributes nothing rather than erasing the others, and an
+   * empty union stays `never`: no member means no payload, not an
+   * unconstrained one.
    */
-  type UnionToIntersection<U> = [U] extends [never] ? never : (U extends unknown ? (x: U) => void : never) extends (x: infer I) => void ? I : never;
+  type BoxedPayload<S, K extends string> = K extends keyof S
+    ? [Exclude<S[K], undefined>] extends [never] ? never : (payload: Exclude<S[K], undefined>) => void
+    : never;
+
+  type PayloadOf<S, K extends string> = [BoxedPayload<S, K>] extends [never]
+    ? never
+    : BoxedPayload<S, K> extends (payload: infer V) => void ? V : never;
 
   /**
    * The parser's own params minus the payload slot the schema takes over. A
@@ -460,7 +471,7 @@ export namespace Schema {
   export type Params<S, K extends string, P extends Parser.Params> = [S] extends [never]
     ? P
     : [K] extends [keyof S]
-      ? Payload<P, UnionToIntersection<Exclude<S[K & keyof S], undefined>>, undefined extends S[K & keyof S] ? true : false>
+      ? Payload<P, PayloadOf<S, K>, undefined extends S[K & keyof S] ? true : false>
       : P;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,8 @@ export namespace Config {
   };
 }
 
+declare const operator: unique symbol;
+
 export namespace Extension {
   export type Input = any;
 
@@ -201,16 +203,53 @@ export namespace Extension {
    */
   export type T<I = Input, O = Output> = (input: I) => O;
 
+  /**
+   * The build-time half of an extension whose output shape depends on the
+   * surface it receives. Extend it and express the result through `this`:
+   *
+   * ```ts
+   * interface WithStores extends Extension.Operator {
+   *   readonly output: this['input'] & { subscribe(): void };
+   * }
+   * ```
+   *
+   * A plain `(input: I) => O` pair cannot carry that dependency. Reading a
+   * generic signature instantiates its type parameters at their constraints,
+   * so the pipe would fold the constraint rather than the instance and the
+   * surface it was handed would be erased.
+   */
+  export interface Operator {
+    readonly input: unknown;
+    readonly output: unknown;
+  }
+
+  /** Applies an `Operator` to the surface reaching it. */
+  export type Apply<O extends Operator, Instance> = (O & { readonly input: Instance })['output'];
+
+  /**
+   * An extension typed by an `Operator` instead of by a fixed return type.
+   * The brand is type-only and optional, so the function is written as usual:
+   *
+   * ```ts
+   * const withStores: Extension.Generic<WithStores> = (i18n) => ...;
+   * ```
+   */
+  export type Generic<O extends Operator> = T & { readonly [operator]?: O };
+
   /** The `extensions` tuple carried by a config; `[]` when absent. */
   export type FromConfig<C> = C extends { extensions: infer E extends readonly T[] } ? E : [];
 
   /**
    * Folds a surface type through an extension tuple, left to right — the
-   * construction-time type of `new I18n(config)`. A non-tuple `extensions`
-   * array (or none at all) degrades to the plain instance type.
+   * construction-time type of `new I18n(config)`. An `Operator`-branded
+   * extension is applied to the surface reaching it; a plain one contributes
+   * its declared return type, erasing what came before. A non-tuple
+   * `extensions` array (or none at all) degrades to the plain instance type.
    */
-  export type Piped<Instance, Extensions> = Extensions extends readonly [T<any, infer O>, ...infer Rest]
-    ? Piped<O, Rest>
+  export type Piped<Instance, Extensions> = Extensions extends readonly [infer Head, ...infer Rest]
+    ? Piped<Head extends { readonly [operator]?: infer O extends Operator }
+      ? Apply<O, Instance>
+      : Head extends T<any, infer Out> ? Out : Instance, Rest>
     : Instance;
 }
 

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -1574,6 +1574,7 @@ describe('type inference', () => {
       'common.placeholder': { value: string };
       'common.optional': { value?: string };
       'common.maybe': { value: string } | undefined;
+      'common.plural': { mode: 'few'; count: number } | { mode: 'many'; total: number };
       'common.loose': any;
     };
 
@@ -1593,6 +1594,11 @@ describe('type inference', () => {
     instance.t('common.maybe', { value: 'a' });
     instance.t('common.maybe');
 
+    // A discriminated payload stays a union — every branch is a valid call.
+    instance.t('common.plural', { mode: 'few', count: 3 });
+    instance.t('common.plural', { mode: 'many', total: 12 });
+    instance.l('en', 'common.plural', { mode: 'few', count: 3 });
+
     // An `any` slot stays unchecked rather than collapsing to "no payload".
     instance.t('common.loose', { anything: true });
     instance.t('common.loose');
@@ -1611,6 +1617,10 @@ describe('type inference', () => {
     instance.t('common.no_placeholder', { value: 'a' });
     // @ts-expect-error payload passed to a message that takes none
     instance.t('common.void', { value: 'a' });
+    // @ts-expect-error branches of a discriminated payload cannot be mixed
+    instance.t('common.plural', { mode: 'few', total: 12 });
+    // @ts-expect-error missing payload behind a discriminated union
+    instance.t('common.plural');
 
     // A key that is a union has to satisfy every key it might be.
     const eitherKey: 'common.no_placeholder' | 'common.placeholder' = 'common.placeholder';

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, it, vi } from 'vitest';
 import i18n from '../../src/index.js';
-import type { Config, I18n, Parser } from '../../src/index.js';
+import type { Config, Extension, I18n, Parser } from '../../src/index.js';
 import { logger, loggerFactory, setLogger } from '../../src/logger.js';
 import { read, sanitizeLocales, testRoute, toDotNotation, translate } from '../../src/utils.js';
 import * as publicUtils from '../../src/exports/utils.js';
@@ -923,6 +923,41 @@ describe('i18n extensions', () => {
     expectTypeOf(widened.locale).not.toEqualTypeOf<'en' | 'de' | (string & {}) | undefined>();
 
     expect(widened).toBeInstanceOf(i18n);
+  });
+  it('an `Operator`-typed extension threads the constructed surface through the pipe', () => {
+    interface WithFirst extends Extension.Operator {
+      readonly output: this['input'] & { first: true };
+    }
+    interface WithSecond extends Extension.Operator {
+      readonly output: this['input'] & { second: true };
+    }
+
+    const withFirst: Extension.Generic<WithFirst> = (input: I18n) => Object.assign(input, { first: true as const });
+    const withSecond: Extension.Generic<WithSecond> = (input: I18n) => Object.assign(input, { second: true as const });
+
+    type Schema = { 'common.key': { count: number } };
+
+    const instance = new i18n({
+      parser,
+      log,
+      initLocale: 'en',
+      fallbackLocale: 'de',
+      schema: {} as Schema,
+      translations: { en: { 'common.key': 'value' } },
+      extensions: [withFirst, withSecond],
+    });
+
+    // Both operators applied, in order, to the surface each was handed.
+    expect(instance.first).toBe(true);
+    expect(instance.second).toBe(true);
+    expect(instance).toBeInstanceOf(i18n);
+
+    // The instance the operators were folded over survives whole: the locale
+    // union the config spelled and the schema that narrows `t` are both intact.
+    expectTypeOf(instance.locale).toEqualTypeOf<'en' | 'de' | (string & {}) | undefined>();
+    expect(instance.t('common.key', { count: 1 })).toBe('common.key');
+    // @ts-expect-error the schema still closes the key set behind the pipe
+    instance.t('common.missing');
   });
 });
 


### PR DESCRIPTION
## What

Three type-level changes to the pre-3.0 public surface:

1. **`Schema.Params` collapsed a discriminated payload to `never`.** The fold ran `UnionToIntersection` over the VALUE union rather than only the key union, so a key holding `{ mode: 'few'; count: number } | { mode: 'many'; total: number }` reduced to an empty intersection, and `Payload` then typed the message as parameterless. Every correct call failed with TS2345. Replaced with `BoxedPayload` / `PayloadOf`, which fold over the KEYS so each key's own payload reaches the intersection whole.
2. **An extension could not keep the surface it was handed.** `(input: I18n) => …` folds the bare instance, so the `schema` and locale union a config narrowed were erased by the pipe. A generic signature fared worse: reading one instantiates its type parameters at their constraints, so the pipe folded `unknown` and dropped the instance entirely. Added `Extension.Operator` / `Extension.Apply` / `Extension.Generic` and taught `Extension.Piped` to apply an operator to the surface reaching it.
3. **`Loader.IndexedKeys` is no longer exported.** It only ever named the shape of the private `#loadedKeys` bookkeeping, which no public method takes or returns.

## Why

(1) and (2) are defects in types that ship in 3.0. (2) additionally unblocks an extension that augments the instance without erasing what the config narrowed. (3) removes a published commitment to internal load state — free now, breaking after the major.

Relates to #218

## How

`BoxedPayload` boxes each key's payload in a function parameter position so the intersection distributes over keys, and `PayloadOf` unboxes it behind an explicit `[BoxedPayload] extends [never]` guard — `never extends (payload: infer V) => void ? V : never` infers `unknown`, not `never`, because distribution over `never` needs a naked type parameter.

`Extension.Operator` is an interface with `readonly input` / `readonly output`; an extension expresses its result through `this['input']`, and `Apply<O, Instance>` instantiates it by intersecting in the concrete input. `Extension.Generic<O>` is `Extension.T` carrying `O` as an optional, type-only `unique symbol` brand, so the function body and signature are written as usual. `Piped` reads the brand when present and otherwise keeps the old behavior — an unbranded extension still contributes its declared return type.

`Loader.IndexedKeys` becomes a module-local `LoadedKeys` alias in `I18n.svelte.ts`. No runtime change.

## Testing

Real local results on the branch tip:

- `npm test` — 121 passed (121)
- `npm run test:dist` — 4 passed (4)
- `npm run build` — clean (`src -> dist`)
- `npm run lint` — clean
- `npm run typecheck` — clean

Both type fixes were verified red before green:

- With `src/types.ts` stashed, the new schema assertions failed with `error TS2345: Argument of type '{ mode: string; count: number; }' is not assignable to parameter of type 'undefined'` (plus the paired `@ts-expect-error` going unused, TS2578).
- With `src/types.ts` stashed, the new extension test failed with `TS2694: Namespace 'Extension' has no exported member 'Operator'` and, in a standalone probe against the old encoding, `TS18046: 'one' is of type 'unknown'` — the pipe had erased the instance outright.

The extension test also asserts that an operator-typed extension leaves `instance.locale` as `'en' | 'de' | (string & {}) | undefined` and keeps the schema closing the key set. The existing seven extension tests, including the one enshrining that an unannotated extension collapses to `any`, are unchanged and still pass.

## Checklist

- [x] **Tests pass locally** (`npm test`)
- [x] **Linter passes** (`npm run lint`)
- [x] **Build succeeds** (`npm run build`)
- [x] **All commits are atomic** (each commit works independently)
- [x] **Commits have clear messages** (imperative mood, descriptive)
- [x] **Branch rebased on latest master** (`git rebase origin/master`)
- [ ] **CHANGELOG.md updated** — this repository has no `CHANGELOG.md`
- [x] **Documentation updated** (`docs/README.md`, `AGENTS.md`)

## Additional Notes

Out of scope, flagged rather than fixed here:

- `docs/README.md` still says "Fresh data replaces the stale keys" in the cache section; the branch-by-branch merge landed since contradicts it.
- The comment in `tsconfig.json` refers to `tsup` inheriting the language level. The build is `svelte-package`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV)_