### PR TITLE
feat(core): reactive `t`/`l` identity, private config seam

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1291,22 +1291,6 @@ the rejection.
 
 ---
 
-### `configLoader(config)`
-
-**Type:** `(config: Config.T) => Promise<void>`
-
-The overridable seam a config is applied through. `loadConfig()` delegates to
-it, and the constructor goes through `loadConfig()`, so a wrapper package that
-subclasses the instance can inject its own defaults and have them apply to
-`new I18n(config)` as well — `sveltekit-i18n` wires its default parser this
-way.
-
-Application code calls [`loadConfig()`](#loadconfigconfig) instead: the public
-entry adds the destroyed-instance guard and marks the rejection handled, and
-this method does neither.
-
----
-
 ### `addTranslations(translations)`
 
 **Type:** `(translations: Record<string, any>) => void`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1093,9 +1093,11 @@ export const i18n = new I18n(config);
 
 Do not destructure value properties off the instance — a destructured value is
 a one-time snapshot. `t` and `l` are functions and stay reactive even when
-destructured, because their tracked reads happen at call time. To use
-destructured value reads in a component, destructure through `$derived` — each
-binding then stays in sync with the instance:
+destructured, because their tracked reads happen at call time. Their identity
+is refreshed whenever the config, the translations or the locale change, so a
+component that only holds the reference — passing `t` to a child, say — is
+tracked as well. To use destructured value reads in a component, destructure
+through `$derived` — each binding then stays in sync with the instance:
 
 ```svelte
 <script>

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -98,40 +98,31 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
   );
 
   /**
-   * Translates `key` for the active locale. Reactive wherever reads are
-   * tracked: the call reads the translation table and locale, so a component
-   * using `{i18n.t('key')}` re-renders when either changes.
+   * Translates `key` for the active locale. Reactive on two levels: the
+   * returned function reads the tables at CALL time, so a destructured `t`
+   * keeps translating against live state, and its identity is refreshed
+   * whenever the config, the tables or the locale change, so merely holding
+   * the reference is tracked too.
    */
-  t: Translations.TranslationFunction<ParserParams, ParserOutput, TranslationSchema> = (key, ...params) => {
-    const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams, ParserOutput>;
+  t: Translations.TranslationFunction<ParserParams, ParserOutput, TranslationSchema> = $derived.by(() => {
+    void this.#config;
+    void this.#translations;
+    void this.#locale;
 
-    return translate<ParserParams, ParserOutput>({
-      parser,
-      key,
-      params,
-      translations: this.#translations,
-      locale: this.#locale,
-      fallbackLocale,
-      ...(hasOwn(rest, 'fallbackValue') ? { fallbackValue: rest.fallbackValue } : {}),
-    });
-  };
+    return (key, ...params) => this.#translate(this.#locale, key, params);
+  });
 
   /** Like `t`, for an explicit locale. */
-  l: Translations.LocalTranslationFunction<ParserParams, ParserOutput, TranslationSchema, LocaleUnion> = (locale, key, ...params) => {
-    const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams, ParserOutput>;
+  l: Translations.LocalTranslationFunction<ParserParams, ParserOutput, TranslationSchema, LocaleUnion> = $derived.by(() => {
+    void this.#config;
+    void this.#translations;
 
-    const [sanitizedLocale = locale] = this.#sanitize(locale);
+    return (locale, key, ...params) => {
+      const [sanitizedLocale = locale] = this.#sanitize(locale);
 
-    return translate<ParserParams, ParserOutput>({
-      parser,
-      key,
-      params,
-      translations: this.#translations,
-      locale: sanitizedLocale,
-      fallbackLocale,
-      ...(hasOwn(rest, 'fallbackValue') ? { fallbackValue: rest.fallbackValue } : {}),
-    });
-  };
+      return this.#translate(sanitizedLocale, key, params);
+    };
+  });
 
   // -- configuration ----------------------------------------------------------
 
@@ -342,6 +333,20 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
   };
 
   // -- internals --------------------------------------------------------------
+
+  #translate(locale: Config.Locale | undefined, key: string, params: Parser.Params): ParserOutput {
+    const { parser, fallbackLocale, ...rest } = this.#config ?? {} as Config.T<ParserParams, ParserOutput>;
+
+    return translate<ParserParams, ParserOutput>({
+      parser,
+      key,
+      params,
+      translations: this.#translations,
+      locale,
+      fallbackLocale,
+      ...(hasOwn(rest, 'fallbackValue') ? { fallbackValue: rest.fallbackValue } : {}),
+    });
+  }
 
   /**
    * Resolves loader data for a locale and route WITHOUT applying it. Returns

--- a/src/I18n.svelte.ts
+++ b/src/I18n.svelte.ts
@@ -50,7 +50,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
     // A constructor may return a substitute object: the instance is folded
     // through `config.extensions` left to right, so `new I18n(config)`
     // evaluates to the last extension's output. The extensions run after the
-    // synchronous part of `configLoader` — they receive a configured instance.
+    // synchronous part of the config load — they receive a configured instance.
     return (config?.extensions ?? []).reduce<any>((acc, extension) => extension(acc), this);
   }
 
@@ -126,11 +126,8 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
 
   // -- configuration ----------------------------------------------------------
 
-  /**
-   * Applies a config. Overridable extension seam — `sveltekit-i18n` wires its
-   * default parser by extending this method.
-   */
-  async configLoader(config: Config.T<ParserParams, ParserOutput>) {
+  /** Applies a config. The public entry is `loadConfig`. */
+  async #configLoader(config: Config.T<ParserParams, ParserOutput>) {
     if (!config) {
       logger.error('No config provided!');
       return;
@@ -187,7 +184,7 @@ class I18nCore<ParserParams extends Parser.Params = any, ParserOutput = string, 
   loadConfig = (config: Config.T<ParserParams, ParserOutput>) => {
     if (this.#inert('loadConfig')) return Promise.resolve();
 
-    const promise = this.configLoader(config);
+    const promise = this.#configLoader(config);
 
     promise.catch((error) => logError('Failed to load the i18n config.', error));
 

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -677,6 +677,55 @@ describe('i18n instance', () => {
     expect(() => instance.t('common.key')).not.toThrow();
     expect(() => instance.l('en', 'common.key')).not.toThrow();
   });
+
+  it('refreshes the `t`/`l` identity when the config, the tables or the locale change', async () => {
+    const valueParser = { parse: (text: any, _params: any, _locale: any, key: string) => (text === undefined ? key : text) };
+    const instance = new i18n({ parser: valueParser, log, initLocale: 'en' });
+
+    const initialT = instance.t;
+    const initialL = instance.l;
+
+    instance.addTranslations({ en: { greeting: 'Hello' }, cs: { greeting: 'Ahoj' } });
+
+    expect(instance.t).not.toBe(initialT);
+    expect(instance.l).not.toBe(initialL);
+
+    const loadedT = instance.t;
+
+    await instance.setLocale('cs');
+
+    expect(instance.t).not.toBe(loadedT);
+
+    const localeT = instance.t;
+    const localeL = instance.l;
+
+    await instance.loadConfig({
+      parser: { parse: (text: any, _params: any, _locale: any, key: string) => `[${text ?? key}]` },
+      log,
+    });
+
+    expect(instance.t).not.toBe(localeT);
+    expect(instance.l).not.toBe(localeL);
+  });
+
+  it('keeps destructured `t`/`l` translating against live state', async () => {
+    const valueParser = { parse: (text: any, _params: any, _locale: any, key: string) => (text === undefined ? key : text) };
+    const instance = new i18n({ parser: valueParser, log, initLocale: 'en' });
+
+    // Snapshotted before any data exists: the reads happen when it is CALLED,
+    // so it must keep up with everything that lands afterwards.
+    const { t, l } = instance;
+
+    instance.addTranslations({ en: { greeting: 'Hello' }, cs: { greeting: 'Ahoj' } });
+    await instance.setLocale('en');
+
+    expect(t('greeting')).toBe('Hello');
+    expect(l('cs', 'greeting')).toBe('Ahoj');
+
+    await instance.setLocale('cs');
+
+    expect(t('greeting')).toBe('Ahoj');
+  });
 });
 
 describe('i18n locale keys', () => {


### PR DESCRIPTION
## What

Two changes to the core, one commit each.

### 1. `t`/`l` identity

`t` and `l` are now `$derived.by` wrappers instead of stable bound fields. The
returned function still resolves the config, the tables and the locale through
the instance at CALL time; what is new is that its *identity* is refreshed
whenever those inputs change.

Both bodies used to duplicate the whole `translate()` call — they now share a
private `#translate`, leaving the tracked reads as the only difference between
them (`l` deliberately does not track `locale`, since it takes an explicit one).

### 2. `configLoader` unpublished

`configLoader` becomes `#configLoader`. `loadConfig` is now the only way in,
and the published instance surface is exactly what consumers call.

## Why

The reference itself carried no signal. A consumer that only *holds* `t` —
passing it to a child component, or projecting it into a store — never learned
that the translations, the locale or the config had moved; only a consumer that
*called* `t` inside a tracked scope was notified.

This is what `@sveltekit-i18n/extension-stores` currently has to work around: it
mirrors `t`'s dependency set from outside the class, and reaches the config only
indirectly through `void i18n.locales`. The dependencies belong where they live.

`configLoader` was public as an overridable seam: v2's `sveltekit-i18n`
subclassed the instance and overrode it to inject `parser-default`. v3 does not
export the class, so nothing can subclass it, and a wrapper package does not
need the hook — it composes `new I18n(config)` with its own config defaults,
and `config.extensions` covers whatever else it wants to wrap (including
`loadConfig`, to re-inject those defaults on a later reconfiguration). A public
method nothing calls is surface we would have to keep.

## How

The derived reads its inputs and returns a lazy wrapper:

```ts
t = $derived.by(() => {
  void this.#config;
  void this.#translations;
  void this.#locale;

  return (key, ...params) => this.#translate(this.#locale, key, params);
});
```

The wrapper deliberately does **not** capture the state into consts. Capturing
would freeze a destructured `t` at the moment of destructuring — silently, with
no error, exactly breaking the documented
`export const { t, locale } = new I18n(config)` idiom. Reading through
`this.#…` at call time keeps destructuring live; only the function identity is
new.

The config is among the tracked inputs because both functions resolve `parser`,
`fallbackLocale` and `fallbackValue` through it, so swapping a parser reaches
holders even when no translation changed.

The seam removal is mechanical: the method becomes private, `loadConfig`
delegates to `this.#configLoader`, and the `configLoader(config)` section
leaves `docs/README.md`.

Measured behavioural delta (client-mode effect probe, three variants: stable
field / lazy derived / eager derived):

- `{i18n.t('key')}` in a component — identical to before.
- an effect that only *holds* `i18n.t` without calling it — now re-runs when the
  inputs change (previously never). That is the intended fix, and the only
  behavioural change.
- destructured `t`/`l` — identical to before (covered by a new regression test).

## Testing

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run build` — `src -> dist`
- `npx vitest run` — `Tests 123 passed (123)` (121 before; 2 added)
- `npm run test:dist` — `Tests 4 passed (4)`

Both commits were verified this way; the tip is green.

Red/green verified in both directions: with `src/I18n.svelte.ts` reverted,
`refreshes the 't'/'l' identity when the config, the tables or the locale
change` fails on the first `l` assertion. `keeps destructured 't'/'l'
translating against live state` passes on the unfixed code by design — it
guards behaviour that must *not* change.

## Checklist

- [x] **Tests pass locally** (`npm test`)
- [x] **Linter passes** (`npm run lint`)
- [x] **Build succeeds** (`npm run build`)
- [x] **All commits are atomic** (each commit works independently)
- [x] **Commits have clear messages** (imperative mood, descriptive)
- [x] **Branch rebased on latest master** (`git rebase origin/master`)
- [ ] **CHANGELOG.md updated** — this repo has no CHANGELOG.md
- [x] **Documentation updated** (`docs/README.md`: destructuring section; `configLoader` section removed)

## Additional Notes

Follow-up in `extensions` (sveltekit-i18n/extensions#1, already updated on its
branch): the `extension-stores` `t`/`l` store getters collapse to
`toStore(() => i18n.t)`, the `void i18n.locales` proxy read goes away, and the
surface-drift guard now asserts `Exclude<keyof I18n, keyof Output>` is `never`
instead of `'configLoader'`. That PR stays a draft until a `base` prerelease
carrying these two commits is published.

Follow-up in `lib`: the v3 wiring of `parser-default` composes instead of
subclassing — a constructor that forwards to `new I18n(config)` with the parser
injected, plus a parser-injecting extension prepended to `config.extensions`, so
a later `loadConfig()` re-injects it too. Settled on sveltekit-i18n/lib#229,
keeping `new I18n(config)` as the public shape.

---
_Generated by [Claude Code](https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV)_