### PR TITLE
ci: publish through the automation app and push atomically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,10 +31,25 @@ jobs:
   publish-npm:
     needs: tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
+      # The release commit lands on a protected branch; the app is on the
+      # bypass allowlist, GITHUB_TOKEN is not.
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.AUTOMATION_APP_PRIVATE_KEY }}
 
-      - uses: actions/setup-node@v7
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
@@ -43,15 +58,18 @@ jobs:
         run: npm install
 
       - name: Update version
+        id: bump
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          npm version ${{ inputs.version }} --preid=${{ inputs.preid }}
+          git config --local user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config --local user.email '${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          echo "tag=$(npm version ${{ inputs.version }} --preid=${{ inputs.preid }} | tail -n 1)" >> "$GITHUB_OUTPUT"
 
-      - name: Push changes
-        run: git push --follow-tags
+      # Atomic: the branch and the tag land together or not at all, and the
+      # publish below never runs on a half-pushed release.
+      - name: Push release commit and tag
+        run: git push --atomic origin HEAD:${{ github.ref_name }} '${{ steps.bump.outputs.tag }}'
 
       - name: Publish package
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --tag ${{ inputs.tag }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Update version
         id: bump

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Test
         run: npm run test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+tag-version-prefix=


### PR DESCRIPTION
## What

Reworks the `NPM Publish` workflow, plus two supporting fixes:

- Mints an installation token with `actions/create-github-app-token@v3` from `AUTOMATION_APP_ID` / `AUTOMATION_APP_PRIVATE_KEY` and hands it to `actions/checkout` as `token:`, so the release push is authenticated as the automation app.
- Drops the job's write scope to `permissions: contents: read` — `GITHUB_TOKEN` no longer writes anything.
- Replaces `git push --follow-tags` with `git push --atomic origin HEAD:<ref> <tag>`. The tag name comes from the `npm version` output via `$GITHUB_OUTPUT` rather than being re-derived from `package.json`.
- Sets the release commit identity to `<app-slug>[bot]`.
- Installs with `npm ci` instead of `npm install`, in both `publish.yml` and `tests.yml`.
- Adds `.npmrc` with an empty `tag-version-prefix`.

## Why

Both publish runs on this repository failed. The last one:

```
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: - Changes must be made through a pull request.
 * [new tag]         v3.0.0-next.1 -> v3.0.0-next.1
 ! [remote rejected] master -> master (protected branch hook declined)
error: failed to push some refs
```

Two independent defects:

1. `GITHUB_TOKEN` is not on the branch-protection bypass allowlist, so the version-bump commit cannot land on `master`. An installation token from the automation app is.
2. `git push --follow-tags` is not atomic. The tag pushed, the branch was rejected, the job exited non-zero and `npm publish` never ran — leaving an orphaned tag and forcing a manual publish of `3.0.0-next.1`.

The second is fixed by pushing branch and tag as one unit, with the push ordered before the publish so an irreversible `npm publish` can never run on a half-pushed release.

Two adjacent problems the same workflow exposed:

- `npm install` runs immediately before `npm version`. If the install rewrites `package-lock.json`, the tree is dirty and `npm version` refuses to run, failing the release for a reason unrelated to the release. `npm ci` installs the lockfile as written.
- Tags in this repository were inconsistently prefixed (`3.0.0-next.0` without `v`, `v3.0.0-next.1` with it) because `npm version` defaults to `v`. The tags have since been normalized to the unprefixed form by hand; pinning `tag-version-prefix=` in `.npmrc` stops both CI and local bumps from reintroducing the prefix.

## How

npm authentication is unchanged (`NPM_TOKEN`); the app token cannot authenticate to npm. Migrating to npm Trusted Publishing (OIDC) is a separate concern and is not part of this PR.

The workflow requires the app to be installed on this repository with `Contents: Read and write` and to sit on the `master` ruleset bypass allowlist. Both are configured.

## Testing

A publish workflow cannot be exercised without a real release run. Verified locally:

```
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/publish.yml')); ..."
['tests', 'publish-npm']
- Mint app token | actions/create-github-app-token@v3
- Checkout | actions/checkout@v7
- Setup Node | actions/setup-node@v7
- Install dependencies |
- Update version |
- Push release commit and tag |
- Publish package |

$ npm ci --dry-run
added 73 packages in 2s

$ npm config get tag-version-prefix     # in repo
$ (cd /tmp && npm config get tag-version-prefix)
v
```

The lockfile is in sync, so `npm ci` will not fail the matrix. The `.npmrc` resolves to an empty prefix inside the repository while the npm default stays `v` outside it.

No `src/` files are touched, so build and test output is unchanged by this diff. The `Tests` matrix runs on this PR.

## Checklist

- [ ] **Tests pass locally** (`npm test`) — not run; no source change, CI matrix covers it
- [x] **Linter passes** (`npm run lint`) — pre-commit hook
- [ ] **Build succeeds** (`npm run build`) — not run; no source change
- [x] **All commits are atomic**
- [x] **Commits have clear messages**
- [x] **Branch rebased on latest master**
- [ ] **CHANGELOG.md updated** — not applicable, CI only
- [ ] **Documentation updated** — not applicable, CI only

## Additional Notes

Out of scope:

- The same rework still needs to be applied to `parsers` (where the two near-identical publish workflows could collapse into one with a `package` input), `lib`, and `extensions` (which has no publish workflow at all).
- The commit identity uses `<app-slug>[bot]` without the bot account's numeric id, so GitHub will not link the release commit to the app account. Cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV