### PR TITLE
ci: create the GitHub release from the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,3 +73,16 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --tag ${{ inputs.tag }}
+
+      # Last: publishing is irreversible, so a release must never announce a
+      # version that failed to reach the registry.
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          case "$TAG" in
+            *-*) PRERELEASE=--prerelease ;;
+            *)   PRERELEASE= ;;
+          esac
+          gh release create "$TAG" --title "$TAG" --generate-notes $PRERELEASE


### PR DESCRIPTION
## What

Adds a final `Create GitHub release` step to the `NPM Publish` workflow:

```yaml
      - name: Create GitHub release
        env:
          GH_TOKEN: ${{ steps.app-token.outputs.token }}
          TAG: ${{ steps.bump.outputs.tag }}
        run: |
          case "$TAG" in
            *-*) PRERELEASE=--prerelease ;;
            *)   PRERELEASE= ;;
          esac
          gh release create "$TAG" --title "$TAG" --generate-notes $PRERELEASE
```

## Why

Every published version already has a GitHub release, but they were cut by hand after the workflow finished. The automation now has a token that can write to this repository, so the last manual step of the release can go too.

The step reproduces the existing convention rather than inventing one. Release `3.0.0-next.1` was named after its tag, marked as a prerelease, and carried a body of the form:

```
## What's Changed
* feat(core): reactive `t`/`l` identity, private config seam by @jarda-svoboda in ...

**Full Changelog**: https://github.com/sveltekit-i18n/base/compare/3.0.0-next.0...3.0.0-next.1
```

That is exactly what `--generate-notes` produces, so `--title "$TAG"` plus generated notes keeps the release page consistent with everything before it.

It runs last, after `npm publish`. Publishing is irreversible while a release is not, so the ordering means a failed publish leaves no release announcing a version that never reached the registry.

## How

`gh` is preinstalled on `ubuntu-latest`; no new action dependency. It authenticates with the app installation token already minted for the push, so the job keeps `permissions: contents: read` for `GITHUB_TOKEN`.

The prerelease flag is derived from the version rather than from the `tag` input, because the dist-tag is free-form text while a semver prerelease is structural — any version containing `-` is a prerelease.

## Testing

The previous revision of this workflow was exercised by a real release: `3.0.0-next.2` published, the tag pushed unprefixed, and the release commit landed on protected `master`. That confirms the app token, the bypass allowlist, the atomic push and `npm ci` all work.

This step itself cannot be exercised outside a release run. Verified locally that the YAML parses with the new step ordered last:

```
- Mint app token
- Checkout
- Setup Node
- Install dependencies
- Update version
- Push release commit and tag
- Publish package
- Create GitHub release
```

and that the prerelease detection classifies the tag shapes this repository actually uses:

```
3.0.0-next.2 -> [--prerelease]
3.0.0        -> []
1.3.8        -> []
3.1.0-rc.0   -> [--prerelease]
```

No `src/` files are touched, so build and test output is unchanged by this diff.

## Checklist

- [ ] **Tests pass locally** (`npm test`) — not run; no source change, CI matrix covers it
- [x] **Linter passes** (`npm run lint`) — pre-commit hook
- [ ] **Build succeeds** (`npm run build`) — not run; no source change
- [x] **All commits are atomic**
- [x] **Commits have clear messages**
- [x] **Branch rebased on latest master**
- [ ] **CHANGELOG.md updated** — not applicable, CI only
- [ ] **Documentation updated** — not applicable, CI only

## Additional Notes

Out of scope:

- `3.0.0-next.2` has no GitHub release yet; it published before this step existed and needs one created by hand.
- The publish rework still needs applying to `parsers` (where the two near-identical publish workflows could collapse into one with a `package` input), `lib`, and `extensions` (which has no publish workflow at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV

---
_Generated by [Claude Code](https://claude.ai/code/session_019C4iSTCqf87mhi1T2hgYzV)_